### PR TITLE
Download incoming connector attachments into run staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ English | [日本語](./README_JA.md)
 - **Thinking Process Isolation**: AI workers automatically wrap reasoning in `<think>` tags. Notifications, summaries, and cleaned outputs hide them, while `kage logs` keeps the raw stream available for debugging.
 - **Web Dashboard**: Execution history, task management, and AI chat — all in one place.
 
-Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Discord, Slack, and Telegram upload every top-level file left there alongside the text output, so tasks should keep only the intended final deliverables in that directory and delete unwanted Markdown/Marp/HTML, downloaded images, and other intermediate assets before finishing.
+Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Incoming connector attachments are downloaded to `KAGE_ARTIFACT_DIR/incoming` for that same run and called out in the prompt so the provider can decide whether to inspect them. Discord, Slack, and Telegram still upload every top-level file left in `KAGE_ARTIFACT_DIR` alongside the text output, so tasks should keep only the intended final deliverables there and delete unwanted Markdown/Marp/HTML, downloaded images, and other intermediate assets before finishing.
 
 Default built-in AI providers: `codex`, `claude`, `gemini`, `opencode`, `copilot`, `aider`.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -39,7 +39,7 @@
 - **多層的な設定**: `.kage/config.local.toml` > `.kage/config.toml` > `~/.kage/config.toml` > デフォルト。
 - **Webダッシュボード**: 実行履歴、タスク管理、AIチャットを一箇所で提供。
 
-connector を使う run では workspace 内の staging directory として `KAGE_ARTIFACT_DIR`（例: `.kage/tmp/connector-artifacts/<run_id>`）が作られます。Discord / Slack / Telegram はその directory に最後に残っている top-level file を本文と一緒にすべて upload するので、そこには PNG / PDF など意図した最終成果物だけを残し、不要な Markdown / Marp / HTML、ダウンロード画像、中間 asset は終了前に削除してください。
+connector を使う run では workspace 内の staging directory として `KAGE_ARTIFACT_DIR`（例: `.kage/tmp/connector-artifacts/<run_id>`）が作られます。受信した connector 添付は同じ run の `KAGE_ARTIFACT_DIR/incoming` に保存され、その場所が prompt に追記されるので provider 側が必要に応じて読む前提です。Discord / Slack / Telegram は `KAGE_ARTIFACT_DIR` 直下に最後に残っている top-level file を本文と一緒にすべて upload するので、そこには PNG / PDF など意図した最終成果物だけを残し、不要な Markdown / Marp / HTML、ダウンロード画像、中間 asset は終了前に削除してください。
 
 デフォルト同梱の AI provider は `codex`, `claude`, `gemini`, `opencode`, `copilot`, `aider` です。
 

--- a/skills/kage/SKILL.md
+++ b/skills/kage/SKILL.md
@@ -91,7 +91,7 @@ working_dir: ../../workspace
 
 Connectors integrate with external chat services. Sending (task notifications via `notify_connectors`) is **always enabled** as long as credentials are configured. Polling (bi-directional chat) is controlled by the `poll` flag.
 
-Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Discord, Slack, and Telegram upload every top-level file left there with the text reply, so leave only the intended final deliverables in that directory and delete unwanted Markdown/Marp/HTML, downloaded images, and other intermediate assets before the run ends.
+Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Incoming connector attachments are downloaded to `KAGE_ARTIFACT_DIR/incoming` for that run and mentioned in the prompt so the provider can decide whether to use them. Discord, Slack, and Telegram upload every top-level file left in `KAGE_ARTIFACT_DIR` with the text reply, so leave only the intended final deliverables in that directory and delete unwanted Markdown/Marp/HTML, downloaded images, and other intermediate assets before the run ends.
 
 ```toml
 [connectors.my_discord]

--- a/src/kage/ai/chat.py
+++ b/src/kage/ai/chat.py
@@ -3,12 +3,16 @@ import os
 import shutil
 import re
 from pathlib import Path
+from typing import Callable
 from ..artifacts import (
+    IncomingAttachmentPreparation,
     build_connector_delivery_prompt,
+    build_connector_incoming_prompt,
     collect_artifacts_from_dir,
     ensure_workspace_artifact_staging_dir,
     inject_connector_delivery_env,
     write_artifact_metadata,
+    write_incoming_artifact_metadata,
 )
 from ..config import get_global_config, render_command_template
 from ..connector_payload import ConnectorAttachment
@@ -22,6 +26,7 @@ PROVIDER_THINKING_TAGS: dict[str, str] = {
     "codex": "thinking",
 }
 DEFAULT_THINKING_TAG = "think"
+IncomingAttachmentPreparer = Callable[[Path], IncomingAttachmentPreparation]
 _QUICK_TAG_RE = re.compile(
     r"<\s*\/?\s*(?:think(?:ing)?|thought|antthinking|antml:thinking|final)\b",
     re.IGNORECASE,
@@ -197,6 +202,7 @@ def _build_chat_invocation(
     working_dir: str | None = None,
     artifact_dir: Path | None = None,
     connector_targets: list[tuple[str, str]] | None = None,
+    extra_sections: list[str] | None = None,
 ):
     config = get_global_config()
     engine_name = config.default_ai_engine
@@ -223,6 +229,10 @@ def _build_chat_invocation(
         parts.append(
             build_connector_delivery_prompt(connector_targets, artifact_dir).strip()
         )
+    for section in extra_sections or []:
+        section_text = section.strip()
+        if section_text:
+            parts.append(section_text)
     parts.append(f"[User Message]\n{message}")
     system_context = "\n\n".join(parts)
 
@@ -286,6 +296,7 @@ def generate_logged_chat_reply(
     execution_kind: str = "connector_poll",
     metadata: dict | None = None,
     project_path: str | None = None,
+    incoming_attachment_preparer: IncomingAttachmentPreparer | None = None,
 ) -> dict:
     from ..db import set_execution_pid, start_execution, update_execution
     from ..executor import prepare_command_for_execution, run_logged_command
@@ -306,6 +317,7 @@ def generate_logged_chat_reply(
         ]
     artifact_staging_dir: Path | None = None
     attachments: list[ConnectorAttachment] = []
+    incoming_preparation = IncomingAttachmentPreparation()
 
     exec_id = start_execution(
         effective_project_path,
@@ -316,6 +328,45 @@ def generate_logged_chat_reply(
     )
     artifact_staging_dir = ensure_workspace_artifact_staging_dir(cwd_path, exec_id)
     write_artifact_metadata(exec_id, artifact_staging_dir, [])
+    if incoming_attachment_preparer is not None:
+        try:
+            incoming_preparation = (
+                incoming_attachment_preparer(artifact_staging_dir)
+                or IncomingAttachmentPreparation()
+            )
+        except Exception as exc:
+            incoming_preparation = IncomingAttachmentPreparation(errors=[str(exc)])
+        write_incoming_artifact_metadata(
+            exec_id,
+            artifact_staging_dir,
+            incoming_preparation.attachments,
+            incoming_preparation.errors,
+        )
+        if incoming_preparation.skip_execution:
+            err = (
+                incoming_preparation.skip_reason
+                or "Skipped before invoking the provider."
+            )
+            write_run_metadata(exec_id, base_metadata)
+            update_execution(
+                exec_id,
+                "ERROR",
+                "",
+                err,
+                output_summary=infer_output_summary("", err),
+            )
+            return {
+                "stdout": "",
+                "stderr": err,
+                "raw_stdout": "",
+                "raw_stderr": err,
+                "returncode": 1,
+                "run_id": exec_id,
+                "attachments": [],
+                "incoming_attachments": incoming_preparation.attachments,
+                "incoming_errors": incoming_preparation.errors,
+                "skipped_execution": True,
+            }
 
     try:
         invocation = _build_chat_invocation(
@@ -324,6 +375,13 @@ def generate_logged_chat_reply(
             working_dir=str(cwd_path),
             artifact_dir=artifact_staging_dir,
             connector_targets=connector_targets,
+            extra_sections=[
+                build_connector_incoming_prompt(
+                    artifact_staging_dir,
+                    incoming_preparation.attachments,
+                    incoming_preparation.errors,
+                )
+            ],
         )
     except Exception as exc:
         err = str(exc)
@@ -342,6 +400,8 @@ def generate_logged_chat_reply(
             "raw_stderr": err,
             "returncode": 1,
             "run_id": exec_id,
+            "incoming_attachments": incoming_preparation.attachments,
+            "incoming_errors": incoming_preparation.errors,
         }
 
     try:
@@ -391,6 +451,8 @@ def generate_logged_chat_reply(
             "returncode": result["returncode"],
             "run_id": exec_id,
             "attachments": attachments,
+            "incoming_attachments": incoming_preparation.attachments,
+            "incoming_errors": incoming_preparation.errors,
         }
     except Exception as exc:
         err = str(exc)
@@ -414,6 +476,8 @@ def generate_logged_chat_reply(
             "returncode": 1,
             "run_id": exec_id,
             "attachments": attachments,
+            "incoming_attachments": incoming_preparation.attachments,
+            "incoming_errors": incoming_preparation.errors,
         }
     finally:
         try:

--- a/src/kage/artifacts.py
+++ b/src/kage/artifacts.py
@@ -1,12 +1,24 @@
 import json
+import re
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from .connector_payload import ConnectorAttachment
-from .runs import write_run_metadata
+from .runs import load_run_metadata, write_run_metadata
 
 ARTIFACT_ENV_VAR = "KAGE_ARTIFACT_DIR"
 CONNECTOR_TARGETS_ENV_VAR = "KAGE_CONNECTOR_TARGETS_JSON"
 ARTIFACT_STAGING_DIRNAME = "connector-artifacts"
+INCOMING_ARTIFACT_DIRNAME = "incoming"
+_INVALID_ARTIFACT_NAME_RE = re.compile(r"[\\/\r\n\t]+")
+
+
+@dataclass
+class IncomingAttachmentPreparation:
+    attachments: list[ConnectorAttachment] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    skip_execution: bool = False
+    skip_reason: str | None = None
 
 
 def ensure_workspace_artifact_staging_dir(base_dir: Path, exec_id: str) -> Path:
@@ -19,6 +31,57 @@ def ensure_workspace_artifact_staging_dir(base_dir: Path, exec_id: str) -> Path:
     )
     artifact_dir.mkdir(parents=True, exist_ok=True)
     return artifact_dir
+
+
+def ensure_workspace_incoming_artifact_dir(artifact_dir: Path) -> Path:
+    incoming_dir = artifact_dir / INCOMING_ARTIFACT_DIRNAME
+    incoming_dir.mkdir(parents=True, exist_ok=True)
+    return incoming_dir
+
+
+def normalize_artifact_filename(
+    filename: str | None,
+    *,
+    fallback_stem: str = "attachment",
+) -> str:
+    candidate = Path((filename or "").strip()).name
+    candidate = candidate.replace("\x00", "")
+    candidate = _INVALID_ARTIFACT_NAME_RE.sub("_", candidate).strip(" .")
+    return candidate or fallback_stem
+
+
+def reserve_artifact_path(
+    directory: Path,
+    filename: str | None,
+    *,
+    fallback_stem: str = "attachment",
+) -> Path:
+    safe_name = normalize_artifact_filename(filename, fallback_stem=fallback_stem)
+    candidate = directory / safe_name
+    stem = candidate.stem or fallback_stem
+    suffix = candidate.suffix
+    index = 1
+    while candidate.exists():
+        candidate = directory / f"{stem}-{index}{suffix}"
+        index += 1
+    return candidate
+
+
+def write_incoming_attachment_bytes(
+    artifact_dir: Path,
+    filename: str | None,
+    payload: bytes,
+    *,
+    fallback_stem: str = "attachment",
+) -> ConnectorAttachment:
+    incoming_dir = ensure_workspace_incoming_artifact_dir(artifact_dir)
+    path = reserve_artifact_path(
+        incoming_dir,
+        filename,
+        fallback_stem=fallback_stem,
+    )
+    path.write_bytes(payload)
+    return ConnectorAttachment.from_path(path)
 
 
 def normalize_connector_targets(
@@ -70,6 +133,36 @@ def build_connector_delivery_prompt(
     )
 
 
+def build_connector_incoming_prompt(
+    artifact_dir: Path,
+    attachments: list[ConnectorAttachment],
+    errors: list[str] | None = None,
+) -> str:
+    error_list = list(errors or [])
+    if not attachments and not error_list:
+        return ""
+
+    incoming_dir = artifact_dir / INCOMING_ARTIFACT_DIRNAME
+    file_lines = "\n".join(f"- `{attachment.name}`" for attachment in attachments)
+    error_lines = "\n".join(f"- {error}" for error in error_list)
+
+    parts = [
+        "\n\n## Connector Incoming Attachments",
+        "The current connector message included file attachments.",
+        f"Downloaded attachment directory: `{incoming_dir}`",
+    ]
+    if attachments:
+        parts.append(
+            "If those files are relevant, inspect them directly from that directory."
+        )
+        parts.append("Downloaded files:")
+        parts.append(file_lines)
+    if error_list:
+        parts.append("Download issues:")
+        parts.append(error_lines)
+    return "\n".join(parts)
+
+
 def inject_connector_delivery_env(
     env: dict[str, str],
     artifact_dir: Path,
@@ -99,14 +192,41 @@ def collect_artifacts_from_dir(
     return attachments
 
 
+def _load_artifact_metadata(exec_id: str) -> dict[str, object]:
+    metadata = load_run_metadata(exec_id)
+    artifacts = metadata.get("artifacts")
+    return dict(artifacts) if isinstance(artifacts, dict) else {}
+
+
 def write_artifact_metadata(
     exec_id: str,
     artifact_dir: Path | None,
     attachments: list[ConnectorAttachment],
 ) -> None:
-    payload = {
-        "dir": str(artifact_dir) if artifact_dir else None,
+    artifacts = _load_artifact_metadata(exec_id)
+    artifacts.update(
+        {
+            "dir": str(artifact_dir) if artifact_dir else None,
+            "files": [attachment.to_metadata() for attachment in attachments],
+            "count": len(attachments),
+        }
+    )
+    write_run_metadata(exec_id, {"artifacts": artifacts}, merge=True)
+
+
+def write_incoming_artifact_metadata(
+    exec_id: str,
+    artifact_dir: Path | None,
+    attachments: list[ConnectorAttachment],
+    errors: list[str] | None = None,
+) -> None:
+    artifacts = _load_artifact_metadata(exec_id)
+    artifacts["incoming"] = {
+        "dir": (
+            str(artifact_dir / INCOMING_ARTIFACT_DIRNAME) if artifact_dir else None
+        ),
         "files": [attachment.to_metadata() for attachment in attachments],
         "count": len(attachments),
+        "errors": list(errors or []),
     }
-    write_run_metadata(exec_id, {"artifacts": payload}, merge=True)
+    write_run_metadata(exec_id, {"artifacts": artifacts}, merge=True)

--- a/src/kage/connectors/base.py
+++ b/src/kage/connectors/base.py
@@ -2,7 +2,9 @@ from abc import ABC, abstractmethod
 import json
 import time
 from pathlib import Path
+import urllib.request
 
+from ..artifacts import write_incoming_attachment_bytes
 from ..connector_payload import (
     ConnectorAttachment,
     ConnectorDelivery,
@@ -54,6 +56,55 @@ class BaseConnector(ABC):
 
     def _build_run_name(self) -> str:
         return f"connector:{self.name}"
+
+    @staticmethod
+    def _build_attachment_only_instruction() -> str:
+        return (
+            "The user sent one or more attachments without any text. "
+            "Inspect the downloaded incoming files if they are relevant and "
+            "respond based on them."
+        )
+
+    @staticmethod
+    def _build_history_entry(content: str, attachment_names: list[str]) -> str:
+        text = content.strip()
+        if not attachment_names:
+            return text
+        attachment_block = "[Attachments]\n" + "\n".join(
+            f"- {name}" for name in attachment_names
+        )
+        if text:
+            return f"{text}\n\n{attachment_block}"
+        return attachment_block
+
+    @staticmethod
+    def _incoming_attachment_failure_reply() -> str:
+        return (
+            "I couldn't download the attached file(s) from the connector, so I "
+            "skipped this run. Please resend them or check the connector permissions."
+        )
+
+    def _download_to_incoming_attachment(
+        self,
+        artifact_dir: Path,
+        url: str,
+        filename: str | None,
+        *,
+        fallback_stem: str,
+        headers: dict[str, str] | None = None,
+    ) -> ConnectorAttachment:
+        request_headers = {"User-Agent": "kage-connector"}
+        if headers:
+            request_headers.update(headers)
+        req = urllib.request.Request(url, headers=request_headers)
+        with urllib.request.urlopen(req) as response:
+            payload = response.read()
+        return write_incoming_attachment_bytes(
+            artifact_dir,
+            filename,
+            payload,
+            fallback_stem=fallback_stem,
+        )
 
     def _write_delivery_metadata(
         self,

--- a/src/kage/connectors/discord.py
+++ b/src/kage/connectors/discord.py
@@ -2,9 +2,11 @@ import json
 import mimetypes
 import urllib.request
 import urllib.error
+from pathlib import Path
 from uuid import uuid4
 from datetime import datetime, timezone
 from ..ai.chat import clean_ai_reply, generate_logged_chat_reply
+from ..artifacts import IncomingAttachmentPreparation
 from ..connector_payload import (
     ConnectorAttachment,
     ConnectorDelivery,
@@ -18,6 +20,48 @@ from .base import BaseConnector
 class DiscordConnector(BaseConnector):
     def __init__(self, name: str, config):
         super().__init__(name, config)
+
+    @staticmethod
+    def _get_attachment_names(message: dict) -> list[str]:
+        names: list[str] = []
+        for index, attachment in enumerate(message.get("attachments") or [], start=1):
+            raw_name = attachment.get("filename")
+            names.append(str(raw_name or f"discord-attachment-{index}"))
+        return names
+
+    def _prepare_incoming_attachments(
+        self,
+        artifact_dir: Path,
+        message: dict,
+        *,
+        has_text: bool,
+    ) -> IncomingAttachmentPreparation:
+        preparation = IncomingAttachmentPreparation()
+        for index, attachment in enumerate(message.get("attachments") or [], start=1):
+            url = attachment.get("url") or attachment.get("proxy_url")
+            filename = attachment.get("filename")
+            fallback_stem = f"discord-attachment-{index}"
+            if not url:
+                preparation.errors.append(
+                    f"{filename or fallback_stem}: Discord attachment URL was missing."
+                )
+                continue
+            try:
+                preparation.attachments.append(
+                    self._download_to_incoming_attachment(
+                        artifact_dir,
+                        str(url),
+                        str(filename) if filename else None,
+                        fallback_stem=fallback_stem,
+                    )
+                )
+            except Exception as exc:
+                preparation.errors.append(f"{filename or fallback_stem}: {exc}")
+
+        if not has_text and not preparation.attachments:
+            preparation.skip_execution = True
+            preparation.skip_reason = self._incoming_attachment_failure_reply()
+        return preparation
 
     def _get_bot_identity(self):
         """Fetch bot's own user id and username using /users/@me."""
@@ -122,7 +166,7 @@ class DiscordConnector(BaseConnector):
                     continue
 
             content = msg.get("content", "").strip()
-            if not content:
+            if not content and not (msg.get("attachments") or []):
                 continue
 
             # Filtering by message age
@@ -145,7 +189,12 @@ class DiscordConnector(BaseConnector):
         # Process the single target message (if any)
         if target_msg:
             content = target_msg.get("content", "").strip()
-            prompt_with_history = f"{identity_context}[Recent Chat History]\n{history_context}\n\n[Current Instruction]\n{content}"
+            attachment_names = self._get_attachment_names(target_msg)
+            prompt_with_history = (
+                f"{identity_context}[Recent Chat History]\n{history_context}\n\n"
+                "[Current Instruction]\n"
+                f"{content or self._build_attachment_only_instruction()}"
+            )
             connector_meta = {
                 "connector": {
                     "name": self.name,
@@ -158,6 +207,8 @@ class DiscordConnector(BaseConnector):
                         "username", ""
                     ),
                     "input_message": content,
+                    "input_attachment_names": attachment_names,
+                    "input_attachment_count": len(attachment_names),
                     "history_snapshot": history_context,
                 }
             }
@@ -167,15 +218,28 @@ class DiscordConnector(BaseConnector):
                 working_dir=self.config.working_dir,
                 run_name=self._build_run_name(),
                 metadata=connector_meta,
+                incoming_attachment_preparer=lambda artifact_dir: (
+                    self._prepare_incoming_attachments(
+                        artifact_dir,
+                        target_msg,
+                        has_text=bool(content),
+                    )
+                ),
             )
             run_id = reply_data.get("run_id")
             reply_text = reply_data.get("stdout", "")
-            if reply_data.get("returncode") != 0 and not reply_text:
+            if reply_data.get("skipped_execution"):
+                reply_text = reply_data.get("stderr", "")
+            elif reply_data.get("returncode") != 0 and not reply_text:
                 err_text = reply_data.get("stderr") or "unknown error"
                 reply_text = f"Error generating reply: {err_text}"
             final_reply_text = clean_ai_reply(reply_text)
             attachments = list(reply_data.get("attachments", []))
-            self._log_history("User", content, run_id=run_id)
+            self._log_history(
+                "User",
+                self._build_history_entry(content, attachment_names),
+                run_id=run_id,
+            )
             delivery = self._post_reply(
                 ConnectorMessage(
                     text=final_reply_text,

--- a/src/kage/connectors/slack.py
+++ b/src/kage/connectors/slack.py
@@ -4,7 +4,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
+from pathlib import Path
 from ..ai.chat import clean_ai_reply, generate_logged_chat_reply
+from ..artifacts import IncomingAttachmentPreparation
 from ..connector_payload import (
     ConnectorAttachment,
     ConnectorDelivery,
@@ -18,6 +20,52 @@ from .base import BaseConnector
 class SlackConnector(BaseConnector):
     def __init__(self, name: str, config):
         super().__init__(name, config)
+
+    @staticmethod
+    def _get_attachment_names(message: dict) -> list[str]:
+        names: list[str] = []
+        for index, file_info in enumerate(message.get("files") or [], start=1):
+            raw_name = file_info.get("name") or file_info.get("title")
+            names.append(str(raw_name or f"slack-file-{index}"))
+        return names
+
+    def _prepare_incoming_attachments(
+        self,
+        artifact_dir: Path,
+        message: dict,
+        *,
+        has_text: bool,
+    ) -> IncomingAttachmentPreparation:
+        preparation = IncomingAttachmentPreparation()
+        auth_headers = {"Authorization": f"Bearer {self.config.bot_token}"}
+        for index, file_info in enumerate(message.get("files") or [], start=1):
+            filename = file_info.get("name") or file_info.get("title")
+            download_url = file_info.get("url_private_download") or file_info.get(
+                "url_private"
+            )
+            fallback_stem = f"slack-file-{index}"
+            if not download_url:
+                preparation.errors.append(
+                    f"{filename or fallback_stem}: Slack download URL was missing."
+                )
+                continue
+            try:
+                preparation.attachments.append(
+                    self._download_to_incoming_attachment(
+                        artifact_dir,
+                        str(download_url),
+                        str(filename) if filename else None,
+                        fallback_stem=fallback_stem,
+                        headers=auth_headers,
+                    )
+                )
+            except Exception as exc:
+                preparation.errors.append(f"{filename or fallback_stem}: {exc}")
+
+        if not has_text and not preparation.attachments:
+            preparation.skip_execution = True
+            preparation.skip_reason = self._incoming_attachment_failure_reply()
+        return preparation
 
     def _get_bot_identity(self):
         """Fetch bot's own user_id and name using auth.test."""
@@ -129,7 +177,7 @@ class SlackConnector(BaseConnector):
                     continue
 
             content = msg.get("text", "").strip()
-            if not content:
+            if not content and not (msg.get("files") or []):
                 continue
 
             # Filtering by message age
@@ -153,7 +201,12 @@ class SlackConnector(BaseConnector):
         # Process the single target message (if any)
         if target_msg:
             content = target_msg.get("text", "").strip()
-            prompt_with_history = f"{identity_context}[Recent Chat History]\n{history_context}\n\n[Current Instruction]\n{content}"
+            attachment_names = self._get_attachment_names(target_msg)
+            prompt_with_history = (
+                f"{identity_context}[Recent Chat History]\n{history_context}\n\n"
+                "[Current Instruction]\n"
+                f"{content or self._build_attachment_only_instruction()}"
+            )
             connector_meta = {
                 "connector": {
                     "name": self.name,
@@ -164,6 +217,8 @@ class SlackConnector(BaseConnector):
                     "source_user_id": str(target_msg.get("user", "")),
                     "source_user_name": str(target_msg.get("user", "")),
                     "input_message": content,
+                    "input_attachment_names": attachment_names,
+                    "input_attachment_count": len(attachment_names),
                     "history_snapshot": history_context,
                 }
             }
@@ -173,14 +228,27 @@ class SlackConnector(BaseConnector):
                 working_dir=self.config.working_dir,
                 run_name=self._build_run_name(),
                 metadata=connector_meta,
+                incoming_attachment_preparer=lambda artifact_dir: (
+                    self._prepare_incoming_attachments(
+                        artifact_dir,
+                        target_msg,
+                        has_text=bool(content),
+                    )
+                ),
             )
             run_id = reply_data.get("run_id")
             reply_text = reply_data.get("stdout", "")
-            if reply_data.get("returncode") != 0 and not reply_text:
+            if reply_data.get("skipped_execution"):
+                reply_text = reply_data.get("stderr", "")
+            elif reply_data.get("returncode") != 0 and not reply_text:
                 err_text = reply_data.get("stderr") or "unknown error"
                 reply_text = f"Error generating reply: {err_text}"
             final_reply_text = clean_ai_reply(reply_text)
-            self._log_history("User", content, run_id=run_id)
+            self._log_history(
+                "User",
+                self._build_history_entry(content, attachment_names),
+                run_id=run_id,
+            )
             delivery = self._post_reply(
                 ConnectorMessage(
                     text=final_reply_text,

--- a/src/kage/connectors/telegram.py
+++ b/src/kage/connectors/telegram.py
@@ -3,8 +3,10 @@ import mimetypes
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
+from pathlib import Path
 from uuid import uuid4
 from ..ai.chat import clean_ai_reply, generate_logged_chat_reply
+from ..artifacts import IncomingAttachmentPreparation
 from ..connector_payload import (
     ConnectorAttachment,
     ConnectorDelivery,
@@ -19,6 +21,128 @@ class TelegramConnector(BaseConnector):
     def __init__(self, name: str, config):
         super().__init__(name, config)
         self.api_base = f"https://api.telegram.org/bot{self.config.bot_token}"
+
+    @staticmethod
+    def _get_message_text(message: dict) -> str:
+        return (message.get("text") or message.get("caption") or "").strip()
+
+    @staticmethod
+    def _select_largest_photo(message: dict) -> dict | None:
+        photos = message.get("photo") or []
+        if not isinstance(photos, list) or not photos:
+            return None
+        return max(
+            (item for item in photos if isinstance(item, dict)),
+            key=lambda item: (
+                int(item.get("file_size", 0)),
+                int(item.get("width", 0)) * int(item.get("height", 0)),
+            ),
+            default=None,
+        )
+
+    def _get_attachment_names(self, message: dict) -> list[str]:
+        names: list[str] = []
+        document = message.get("document")
+        if isinstance(document, dict):
+            names.append(str(document.get("file_name") or "telegram-document"))
+        largest_photo = self._select_largest_photo(message)
+        if largest_photo is not None:
+            names.append("telegram-photo.jpg")
+        return names
+
+    def _get_file_info(self, file_id: str) -> dict:
+        req = urllib.request.Request(
+            f"{self.api_base}/getFile?file_id={file_id}",
+            headers={"User-Agent": "kage-connector"},
+        )
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode())
+
+    def _prepare_telegram_file(
+        self,
+        artifact_dir: Path,
+        *,
+        file_id: str,
+        filename: str | None,
+        fallback_stem: str,
+    ) -> ConnectorAttachment:
+        file_info = self._get_file_info(file_id)
+        if not file_info.get("ok"):
+            raise RuntimeError(str(file_info.get("description") or "Telegram getFile"))
+        result = file_info.get("result") or {}
+        file_path = result.get("file_path")
+        if not file_path:
+            raise RuntimeError("Telegram getFile response was missing file_path.")
+        resolved_name = filename
+        if not resolved_name:
+            suffix = Path(str(file_path)).suffix
+            resolved_name = f"{fallback_stem}{suffix}" if suffix else fallback_stem
+        return self._download_to_incoming_attachment(
+            artifact_dir,
+            f"https://api.telegram.org/file/bot{self.config.bot_token}/{file_path}",
+            resolved_name,
+            fallback_stem=fallback_stem,
+        )
+
+    def _prepare_incoming_attachments(
+        self,
+        artifact_dir: Path,
+        message: dict,
+        *,
+        has_text: bool,
+    ) -> IncomingAttachmentPreparation:
+        preparation = IncomingAttachmentPreparation()
+
+        document = message.get("document")
+        if isinstance(document, dict):
+            file_id = document.get("file_id")
+            if file_id:
+                try:
+                    preparation.attachments.append(
+                        self._prepare_telegram_file(
+                            artifact_dir,
+                            file_id=str(file_id),
+                            filename=(
+                                str(document.get("file_name"))
+                                if document.get("file_name")
+                                else None
+                            ),
+                            fallback_stem="telegram-document",
+                        )
+                    )
+                except Exception as exc:
+                    preparation.errors.append(
+                        f"{document.get('file_name') or 'telegram-document'}: {exc}"
+                    )
+            else:
+                preparation.errors.append(
+                    "telegram-document: Telegram document file_id was missing."
+                )
+
+        largest_photo = self._select_largest_photo(message)
+        if largest_photo is not None:
+            photo_file_id = largest_photo.get("file_id")
+            if photo_file_id:
+                try:
+                    preparation.attachments.append(
+                        self._prepare_telegram_file(
+                            artifact_dir,
+                            file_id=str(photo_file_id),
+                            filename=None,
+                            fallback_stem="telegram-photo",
+                        )
+                    )
+                except Exception as exc:
+                    preparation.errors.append(f"telegram-photo: {exc}")
+            else:
+                preparation.errors.append(
+                    "telegram-photo: Telegram photo file_id was missing."
+                )
+
+        if not has_text and not preparation.attachments:
+            preparation.skip_execution = True
+            preparation.skip_reason = self._incoming_attachment_failure_reply()
+        return preparation
 
     def _get_bot_identity(self):
         """Fetch bot's own user id and username using getMe."""
@@ -102,7 +226,7 @@ class TelegramConnector(BaseConnector):
         for msg in chat_messages:
             from_user = msg.get("from", {})
             is_bot = from_user.get("is_bot", False)
-            content_text = msg.get("text", "").strip()
+            content_text = self._get_message_text(msg)
             if content_text:
                 if is_bot and bot_user_id and str(from_user.get("id")) == bot_user_id:
                     role = "Assistant"
@@ -133,8 +257,10 @@ class TelegramConnector(BaseConnector):
                 if author_id != str(self.config.user_id):
                     continue
 
-            content = msg.get("text", "").strip()
-            if not content:
+            content = self._get_message_text(msg)
+            if not content and not (
+                isinstance(msg.get("document"), dict) or self._select_largest_photo(msg)
+            ):
                 continue
 
             # Filtering by message age
@@ -151,8 +277,13 @@ class TelegramConnector(BaseConnector):
 
         # Process the single target message (if any)
         if target_msg:
-            content = target_msg.get("text", "").strip()
-            prompt_with_history = f"{identity_context}[Recent Chat History]\n{history_context}\n\n[Current Instruction]\n{content}"
+            content = self._get_message_text(target_msg)
+            attachment_names = self._get_attachment_names(target_msg)
+            prompt_with_history = (
+                f"{identity_context}[Recent Chat History]\n{history_context}\n\n"
+                "[Current Instruction]\n"
+                f"{content or self._build_attachment_only_instruction()}"
+            )
             from_user = target_msg.get("from", {})
             connector_meta = {
                 "connector": {
@@ -167,6 +298,8 @@ class TelegramConnector(BaseConnector):
                         or from_user.get("username", "")
                     ),
                     "input_message": content,
+                    "input_attachment_names": attachment_names,
+                    "input_attachment_count": len(attachment_names),
                     "history_snapshot": history_context,
                 }
             }
@@ -176,14 +309,27 @@ class TelegramConnector(BaseConnector):
                 working_dir=self.config.working_dir,
                 run_name=self._build_run_name(),
                 metadata=connector_meta,
+                incoming_attachment_preparer=lambda artifact_dir: (
+                    self._prepare_incoming_attachments(
+                        artifact_dir,
+                        target_msg,
+                        has_text=bool(content),
+                    )
+                ),
             )
             run_id = reply_data.get("run_id")
             reply_text = reply_data.get("stdout", "")
-            if reply_data.get("returncode") != 0 and not reply_text:
+            if reply_data.get("skipped_execution"):
+                reply_text = reply_data.get("stderr", "")
+            elif reply_data.get("returncode") != 0 and not reply_text:
                 err_text = reply_data.get("stderr") or "unknown error"
                 reply_text = f"Error generating reply: {err_text}"
             final_reply_text = clean_ai_reply(reply_text)
-            self._log_history("User", content, run_id=run_id)
+            self._log_history(
+                "User",
+                self._build_history_entry(content, attachment_names),
+                run_id=run_id,
+            )
             delivery = self._post_reply(
                 ConnectorMessage(
                     text=final_reply_text,

--- a/src/kage/main.py
+++ b/src/kage/main.py
@@ -23,7 +23,7 @@ project_app = typer.Typer(help="Manage registered projects")
 app.add_typer(project_app, name="project")
 
 connector_app = typer.Typer(
-    help="Manage chat connectors (Discord, Slack, Telegram, etc.), including Discord artifact uploads"
+    help="Manage chat connectors (Discord, Slack, Telegram, etc.), including artifact uploads and incoming attachment downloads"
 )
 app.add_typer(connector_app, name="connector")
 
@@ -293,6 +293,10 @@ def _print_run_details(record, json_output: bool = False):
 
     metadata = load_run_metadata(record)
     connector_meta = metadata.get("connector", {}) if isinstance(metadata, dict) else {}
+    artifacts_meta = metadata.get("artifacts", {}) if isinstance(metadata, dict) else {}
+    incoming_meta = (
+        artifacts_meta.get("incoming", {}) if isinstance(artifacts_meta, dict) else {}
+    )
 
     if json_output:
         payload = record.to_dict()
@@ -333,6 +337,16 @@ def _print_run_details(record, json_output: bool = False):
                 ("source_user", connector_meta.get("source_user_name", "-")),
                 ("source_user_id", connector_meta.get("source_user_id", "-")),
                 ("reply_id", connector_meta.get("posted_reply_id", "-")),
+            ]
+        )
+    if incoming_meta:
+        details.extend(
+            [
+                ("incoming_attachment_dir", incoming_meta.get("dir", "-")),
+                (
+                    "incoming_attachment_count",
+                    str(incoming_meta.get("count", 0)),
+                ),
             ]
         )
     for key, value in details:
@@ -1462,14 +1476,14 @@ def doctor():
     )
     t_connector_artifacts = "connector artifacts" if not is_ja else "connector 添付"
     t_connector_artifacts_detail = (
-        "Connector-aware runs export KAGE_ARTIFACT_DIR as a workspace-local staging directory. Discord, Slack, and Telegram upload every top-level file left there, so keep only intended final deliverables there and delete source or intermediate files before the run ends unless they were explicitly requested."
+        "Connector-aware runs export KAGE_ARTIFACT_DIR as a workspace-local staging directory. Incoming connector attachments are downloaded to KAGE_ARTIFACT_DIR/incoming for that run, and Discord, Slack, and Telegram upload every top-level file left in KAGE_ARTIFACT_DIR, so keep only intended final deliverables there and delete source or intermediate files before the run ends unless they were explicitly requested."
         if not is_ja
-        else "connector を使う run では workspace 内 staging directory として KAGE_ARTIFACT_DIR を export します。Discord / Slack / Telegram は最後に残っている top-level file をすべて upload するので、そこには意図した最終成果物だけを残し、source や中間 file は明示的に求められた場合以外は終了前に削除してください。"
+        else "connector を使う run では workspace 内 staging directory として KAGE_ARTIFACT_DIR を export します。受信した connector 添付はその run の KAGE_ARTIFACT_DIR/incoming に保存され、Discord / Slack / Telegram は KAGE_ARTIFACT_DIR 直下に最後に残っている top-level file をすべて upload するので、そこには意図した最終成果物だけを残し、source や中間 file は明示的に求められた場合以外は終了前に削除してください。"
     )
     t_connector_artifacts_detail_empty = (
-        "KAGE_ARTIFACT_DIR is created only for runs that send connector messages."
+        "KAGE_ARTIFACT_DIR is created only for connector-aware runs, including connector poll replies."
         if not is_ja
-        else "KAGE_ARTIFACT_DIR は connector へ送信する run でのみ作られます。"
+        else "KAGE_ARTIFACT_DIR は connector-aware な run でのみ作られ、connector poll reply でも利用されます。"
     )
 
     console = Console()
@@ -2160,7 +2174,7 @@ system_prompt = "Optional additional instructions for this connector"
 ```
 
 > **⚠️ Security**: `poll = true` allows anyone in the channel to interact with the AI, which has full access to your PC. Task notifications (via `notify_connectors`) work even with `poll = false`.
-> **Artifacts**: Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Discord, Slack, and Telegram upload every top-level file left there with the text reply or task notification, so leave only the intended final deliverables there and delete source Markdown/Marp/HTML, downloaded images, and other intermediate assets unless the user explicitly asked for them.
+> **Artifacts**: Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Incoming connector attachments are downloaded to `KAGE_ARTIFACT_DIR/incoming` for that run, and Discord, Slack, and Telegram upload every top-level file left in `KAGE_ARTIFACT_DIR` with the text reply or task notification, so leave only the intended final deliverables there and delete source Markdown/Marp/HTML, downloaded images, and other intermediate assets unless the user explicitly asked for them.
 """
         console.print(
             Panel(Markdown(text), title="Discord Setup", border_style="magenta")
@@ -2197,7 +2211,7 @@ system_prompt = "Optional additional instructions for this connector"
 ```
 
 > **⚠️ Security**: `poll = true` allows anyone in the channel to interact with the AI, which has full access to your PC. Task notifications (via `notify_connectors`) work even with `poll = false`.
-> **Artifacts**: Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Slack uploads every top-level file left there with the text reply or task notification, so leave only the intended final deliverables there and delete source Markdown/Marp/HTML, downloaded images, and other intermediate assets unless the user explicitly asked for them.
+> **Artifacts**: Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Incoming connector attachments are downloaded to `KAGE_ARTIFACT_DIR/incoming` for that run, and Slack uploads every top-level file left in `KAGE_ARTIFACT_DIR` with the text reply or task notification, so leave only the intended final deliverables there and delete source Markdown/Marp/HTML, downloaded images, and other intermediate assets unless the user explicitly asked for them.
 """
         console.print(Panel(Markdown(text), title="Slack Setup", border_style="blue"))
     elif ctype == "telegram":
@@ -2223,7 +2237,7 @@ system_prompt = "Optional additional instructions for this connector"
 ```
 
 > **⚠️ Security**: `poll = true` allows anyone in the chat to interact with the AI, which has full access to your PC. Task notifications (via `notify_connectors`) work even with `poll = false`.
-> **Artifacts**: Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Telegram uploads every top-level file left there with the text reply or task notification, so leave only the intended final deliverables there and delete source Markdown/Marp/HTML, downloaded images, and other intermediate assets unless the user explicitly asked for them.
+> **Artifacts**: Connector-aware runs export `KAGE_ARTIFACT_DIR` as a workspace-local staging directory (for example `.kage/tmp/connector-artifacts/<run_id>`). Incoming connector attachments are downloaded to `KAGE_ARTIFACT_DIR/incoming` for that run, and Telegram uploads every top-level file left in `KAGE_ARTIFACT_DIR` with the text reply or task notification, so leave only the intended final deliverables there and delete source Markdown/Marp/HTML, downloaded images, and other intermediate assets unless the user explicitly asked for them.
 """
         console.print(
             Panel(Markdown(text), title="Telegram Setup", border_style="cyan")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -10,6 +10,10 @@ from kage.ai.chat import (
     generate_logged_chat_reply,
     get_thinking_tag,
 )
+from kage.artifacts import (
+    IncomingAttachmentPreparation,
+    write_incoming_attachment_bytes,
+)
 from kage.config import GlobalConfig, ProviderConfig, CommandDef
 from kage.runs import get_run, load_run_metadata
 
@@ -193,3 +197,106 @@ def test_generate_logged_chat_reply_creates_run_and_metadata(
     assert "reference them with relative paths" in metadata["prompt"]
     assert metadata["artifacts"]["files"][0]["name"] == "reply.txt"
     assert metadata["artifacts"]["dir"] == seen_env["KAGE_ARTIFACT_DIR"]
+
+
+@patch("kage.ai.chat.get_global_config")
+def test_generate_logged_chat_reply_includes_incoming_attachment_prompt_and_metadata(
+    mock_get_config, logged_chat_env, mocker
+):
+    config = GlobalConfig()
+    config.default_ai_engine = "dummy"
+    config.providers["dummy"] = ProviderConfig(command="dummy_cmd")
+    config.commands["dummy_cmd"] = CommandDef(template=["dummy", "chat", "{prompt}"])
+    mock_get_config.return_value = config
+
+    mocker.patch(
+        "kage.executor.prepare_command_for_execution", side_effect=lambda cmd, env: cmd
+    )
+    captured_cmd: list[str] = []
+
+    def fake_run_logged_command(*, cmd, cwd, env, exec_id):
+        del cwd, exec_id, env
+        captured_cmd[:] = cmd
+        return {
+            "stdout": "hello human",
+            "stderr": "",
+            "returncode": 0,
+            "stdout_bytes": 11,
+            "stderr_bytes": 0,
+            "last_output_at": datetime.now().astimezone().isoformat(),
+            "pid": 4242,
+        }
+
+    mocker.patch(
+        "kage.executor.run_logged_command", side_effect=fake_run_logged_command
+    )
+
+    def incoming_preparer(artifact_dir: Path) -> IncomingAttachmentPreparation:
+        attachment = write_incoming_attachment_bytes(
+            artifact_dir,
+            "notes.txt",
+            b"incoming payload",
+        )
+        return IncomingAttachmentPreparation(
+            attachments=[attachment],
+            errors=["preview image failed to download"],
+        )
+
+    result = generate_logged_chat_reply(
+        "hi",
+        working_dir=str(logged_chat_env["logs_dir"].parent),
+        run_name="connector:test",
+        metadata={"connector": {"name": "test_connector", "type": "discord"}},
+        incoming_attachment_preparer=incoming_preparer,
+    )
+
+    prompt_arg = captured_cmd[-1]
+    assert "## Connector Incoming Attachments" in prompt_arg
+    assert "notes.txt" in prompt_arg
+    assert "preview image failed to download" in prompt_arg
+    assert "connector-artifacts" in prompt_arg
+    assert [item.name for item in result["incoming_attachments"]] == ["notes.txt"]
+    metadata = load_run_metadata(result["run_id"])
+    assert metadata["artifacts"]["incoming"]["count"] == 1
+    assert metadata["artifacts"]["incoming"]["files"][0]["name"] == "notes.txt"
+    assert metadata["artifacts"]["incoming"]["dir"].endswith("/incoming")
+    assert metadata["artifacts"]["incoming"]["errors"] == [
+        "preview image failed to download"
+    ]
+
+
+@patch("kage.ai.chat.get_global_config")
+def test_generate_logged_chat_reply_can_skip_provider_before_execution(
+    mock_get_config, logged_chat_env, mocker
+):
+    config = GlobalConfig()
+    config.default_ai_engine = "dummy"
+    config.providers["dummy"] = ProviderConfig(command="dummy_cmd")
+    config.commands["dummy_cmd"] = CommandDef(template=["dummy", "chat", "{prompt}"])
+    mock_get_config.return_value = config
+
+    run_logged_command = mocker.patch("kage.executor.run_logged_command")
+
+    result = generate_logged_chat_reply(
+        "hi",
+        working_dir=str(logged_chat_env["logs_dir"].parent),
+        run_name="connector:test",
+        metadata={"connector": {"name": "test_connector", "type": "discord"}},
+        incoming_attachment_preparer=lambda artifact_dir: IncomingAttachmentPreparation(
+            errors=["download failed"],
+            skip_execution=True,
+            skip_reason="incoming download failed",
+        ),
+    )
+
+    assert result["returncode"] == 1
+    assert result["skipped_execution"] is True
+    assert result["stderr"] == "incoming download failed"
+    run_logged_command.assert_not_called()
+    run = get_run(result["run_id"])
+    assert run is not None
+    assert run.status == "ERROR"
+    metadata = load_run_metadata(result["run_id"])
+    assert metadata["connector"]["name"] == "test_connector"
+    assert metadata["artifacts"]["incoming"]["count"] == 0
+    assert metadata["artifacts"]["incoming"]["errors"] == ["download failed"]

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -95,6 +95,77 @@ def test_discord_connector_poll_and_reply(
     mock_write_metadata.assert_called_once()
 
 
+@patch("kage.connectors.base.BaseConnector._write_delivery_metadata")
+@patch("kage.connectors.discord.urllib.request.urlopen")
+@patch("kage.connectors.discord.generate_logged_chat_reply")
+@patch("kage.connectors.discord.write_run_metadata")
+def test_discord_connector_poll_and_reply_attachment_only(
+    mock_write_metadata, mock_chat, mock_urlopen, mock_write_delivery, tmp_path
+):
+    config = DiscordConnectorConfig(active=True, bot_token="token", channel_id="123")
+    connector = DiscordConnector("test_discord", config)
+    connector.state_file = tmp_path / "discord_state.json"
+    connector.history_file = tmp_path / "discord_history.jsonl"
+
+    from datetime import datetime, timezone
+
+    recent_ts = datetime.now(timezone.utc).isoformat()
+
+    mock_identity_response = MagicMock()
+    mock_identity_response.__enter__.return_value = mock_identity_response
+    mock_identity_response.read.return_value = json.dumps(
+        {"id": "999", "username": "kage"}
+    ).encode("utf-8")
+
+    mock_get_response = MagicMock()
+    mock_get_response.__enter__.return_value = mock_get_response
+    mock_get_response.read.return_value = json.dumps(
+        [
+            {
+                "id": "1",
+                "content": "",
+                "attachments": [
+                    {
+                        "filename": "spec.txt",
+                        "url": "https://cdn.discord.test/spec.txt",
+                    }
+                ],
+                "author": {"bot": False},
+                "timestamp": recent_ts,
+            }
+        ]
+    ).encode("utf-8")
+
+    mock_post_response = MagicMock()
+    mock_post_response.__enter__.return_value = mock_post_response
+    mock_post_response.read.return_value = json.dumps({"id": "2"}).encode("utf-8")
+
+    mock_urlopen.side_effect = [
+        mock_get_response,
+        mock_identity_response,
+        mock_post_response,
+    ]
+    mock_chat.return_value = {
+        "stdout": "attachment handled",
+        "stderr": "",
+        "returncode": 0,
+        "run_id": "run-discord-attachment",
+    }
+
+    connector.poll_and_reply()
+
+    actual_prompt = mock_chat.call_args[0][0]
+    assert "attachments without any text" in actual_prompt
+    assert "incoming_attachment_preparer" in mock_chat.call_args.kwargs
+    history = [
+        json.loads(line)
+        for line in connector.history_file.read_text(encoding="utf-8").splitlines()
+    ]
+    assert "spec.txt" in history[0]["content"]
+    mock_write_delivery.assert_called_once()
+    mock_write_metadata.assert_called_once()
+
+
 @patch("kage.connectors.discord.urllib.request.urlopen")
 def test_discord_connector_ignores_bot_messages(mock_urlopen, tmp_path):
     config = DiscordConnectorConfig(active=True, bot_token="token", channel_id="123")
@@ -177,6 +248,63 @@ def test_discord_send_message_falls_back_to_text_when_upload_fails(
     assert any("upload failed" in err for err in delivery.errors)
     fallback_request = mock_urlopen.call_args.args[0]
     assert fallback_request.headers["Content-type"] == "application/json"
+
+
+@patch("kage.connectors.base.urllib.request.urlopen")
+def test_discord_prepare_incoming_attachments_downloads_files(mock_urlopen, tmp_path):
+    config = DiscordConnectorConfig(bot_token="token", channel_id="123")
+    connector = DiscordConnector("test_discord", config)
+
+    download_response = MagicMock()
+    download_response.__enter__.return_value = download_response
+    download_response.read.return_value = b"discord attachment"
+    mock_urlopen.return_value = download_response
+
+    preparation = connector._prepare_incoming_attachments(
+        tmp_path / "artifacts",
+        {
+            "attachments": [
+                {
+                    "filename": "spec.txt",
+                    "url": "https://cdn.discord.test/spec.txt",
+                }
+            ]
+        },
+        has_text=True,
+    )
+
+    assert [item.name for item in preparation.attachments] == ["spec.txt"]
+    assert preparation.errors == []
+    assert preparation.skip_execution is False
+    assert preparation.attachments[0].path.read_text(encoding="utf-8") == (
+        "discord attachment"
+    )
+
+
+@patch("kage.connectors.base.urllib.request.urlopen")
+def test_discord_prepare_incoming_attachments_marks_skip_for_attachment_only_failure(
+    mock_urlopen, tmp_path
+):
+    config = DiscordConnectorConfig(bot_token="token", channel_id="123")
+    connector = DiscordConnector("test_discord", config)
+    mock_urlopen.side_effect = Exception("download failed")
+
+    preparation = connector._prepare_incoming_attachments(
+        tmp_path / "artifacts",
+        {
+            "attachments": [
+                {
+                    "filename": "spec.txt",
+                    "url": "https://cdn.discord.test/spec.txt",
+                }
+            ]
+        },
+        has_text=False,
+    )
+
+    assert preparation.attachments == []
+    assert preparation.skip_execution is True
+    assert "skipped this run" in (preparation.skip_reason or "")
 
 
 # === Telegram Connector Tests ===
@@ -271,6 +399,83 @@ def test_telegram_connector_poll_and_reply(
     mock_write_metadata.assert_called_once()
 
 
+@patch("kage.connectors.base.BaseConnector._write_delivery_metadata")
+@patch("kage.connectors.telegram.urllib.request.urlopen")
+@patch("kage.connectors.telegram.generate_logged_chat_reply")
+@patch("kage.connectors.telegram.write_run_metadata")
+def test_telegram_connector_poll_and_reply_attachment_only(
+    mock_write_metadata, mock_chat, mock_urlopen, mock_write_delivery, tmp_path
+):
+    import time
+
+    config = TelegramConnectorConfig(poll=True, bot_token="123456:ABC", chat_id="789")
+    connector = TelegramConnector("test_telegram", config)
+    connector.state_file = tmp_path / "telegram_state.json"
+    connector.history_file = tmp_path / "telegram_history.jsonl"
+
+    now_unix = int(time.time())
+
+    mock_updates_response = MagicMock()
+    mock_updates_response.__enter__.return_value = mock_updates_response
+    mock_updates_response.read.return_value = json.dumps(
+        {
+            "ok": True,
+            "result": [
+                {
+                    "update_id": 100,
+                    "message": {
+                        "message_id": 1,
+                        "from": {"id": 42, "is_bot": False, "first_name": "User"},
+                        "chat": {"id": 789},
+                        "date": now_unix,
+                        "document": {
+                            "file_id": "DOC1",
+                            "file_name": "spec.txt",
+                        },
+                    },
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+    mock_me_response = MagicMock()
+    mock_me_response.__enter__.return_value = mock_me_response
+    mock_me_response.read.return_value = json.dumps(
+        {"ok": True, "result": {"id": 999, "is_bot": True, "username": "kage_bot"}}
+    ).encode("utf-8")
+
+    mock_send_response = MagicMock()
+    mock_send_response.__enter__.return_value = mock_send_response
+    mock_send_response.read.return_value = json.dumps(
+        {"ok": True, "result": {"message_id": 2}}
+    ).encode("utf-8")
+
+    mock_urlopen.side_effect = [
+        mock_updates_response,
+        mock_me_response,
+        mock_send_response,
+    ]
+    mock_chat.return_value = {
+        "stdout": "attachment handled",
+        "stderr": "",
+        "returncode": 0,
+        "run_id": "run-telegram-attachment",
+    }
+
+    connector.poll_and_reply()
+
+    actual_prompt = mock_chat.call_args[0][0]
+    assert "attachments without any text" in actual_prompt
+    assert "incoming_attachment_preparer" in mock_chat.call_args.kwargs
+    history = [
+        json.loads(line)
+        for line in connector.history_file.read_text(encoding="utf-8").splitlines()
+    ]
+    assert "spec.txt" in history[0]["content"]
+    mock_write_delivery.assert_called_once()
+    mock_write_metadata.assert_called_once()
+
+
 @patch("kage.connectors.telegram.urllib.request.urlopen")
 def test_telegram_connector_ignores_bot_messages(mock_urlopen, tmp_path):
     import time
@@ -311,6 +516,81 @@ def test_telegram_connector_ignores_bot_messages(mock_urlopen, tmp_path):
     assert connector.state_file.exists()
     state = json.loads(connector.state_file.read_text())
     assert state["last_update_id"] == "200"
+
+
+@patch("kage.connectors.base.BaseConnector._write_delivery_metadata")
+@patch("kage.connectors.slack.urllib.request.urlopen")
+@patch("kage.connectors.slack.generate_logged_chat_reply")
+@patch("kage.connectors.slack.write_run_metadata")
+def test_slack_connector_poll_and_reply_attachment_only(
+    mock_write_metadata, mock_chat, mock_urlopen, mock_write_delivery, tmp_path
+):
+    import time
+
+    config = SlackConnectorConfig(poll=True, bot_token="token", channel_id="C123")
+    connector = SlackConnector("test_slack", config)
+    connector.state_file = tmp_path / "slack_state.json"
+    connector.history_file = tmp_path / "slack_history.jsonl"
+
+    now_unix = time.time()
+
+    history_response = MagicMock()
+    history_response.__enter__.return_value = history_response
+    history_response.read.return_value = json.dumps(
+        {
+            "ok": True,
+            "messages": [
+                {
+                    "ts": str(now_unix),
+                    "text": "",
+                    "user": "U123",
+                    "files": [
+                        {
+                            "name": "brief.pdf",
+                            "url_private_download": "https://files.slack.test/download/brief.pdf",
+                        }
+                    ],
+                }
+            ],
+        }
+    ).encode("utf-8")
+
+    identity_response = MagicMock()
+    identity_response.__enter__.return_value = identity_response
+    identity_response.read.return_value = json.dumps(
+        {"ok": True, "user_id": "B123", "user": "kage"}
+    ).encode("utf-8")
+
+    send_response = MagicMock()
+    send_response.__enter__.return_value = send_response
+    send_response.read.return_value = json.dumps({"ok": True, "ts": "171.02"}).encode(
+        "utf-8"
+    )
+
+    mock_urlopen.side_effect = [
+        history_response,
+        identity_response,
+        send_response,
+    ]
+    mock_chat.return_value = {
+        "stdout": "attachment handled",
+        "stderr": "",
+        "returncode": 0,
+        "run_id": "run-slack-attachment",
+    }
+
+    connector.poll_and_reply()
+
+    actual_prompt = mock_chat.call_args[0][0]
+    assert "attachments without any text" in actual_prompt
+    assert "incoming_attachment_preparer" in mock_chat.call_args.kwargs
+    history = [
+        json.loads(line)
+        for line in connector.history_file.read_text(encoding="utf-8").splitlines()
+    ]
+    assert "brief.pdf" in history[0]["content"]
+    mock_write_delivery.assert_called_once()
+    mock_write_metadata.assert_called_once()
 
 
 @patch("kage.connectors.slack.urllib.request.urlopen")
@@ -489,6 +769,37 @@ def test_slack_send_message_skips_failed_attachments_with_metadata(
     assert any("missing_scope" in err for err in delivery.errors)
 
 
+@patch("kage.connectors.base.urllib.request.urlopen")
+def test_slack_prepare_incoming_attachments_downloads_private_files(
+    mock_urlopen, tmp_path
+):
+    config = SlackConnectorConfig(bot_token="token", channel_id="C123")
+    connector = SlackConnector("test_slack", config)
+
+    download_response = MagicMock()
+    download_response.__enter__.return_value = download_response
+    download_response.read.return_value = b"slack attachment"
+    mock_urlopen.return_value = download_response
+
+    preparation = connector._prepare_incoming_attachments(
+        tmp_path / "artifacts",
+        {
+            "files": [
+                {
+                    "name": "brief.pdf",
+                    "url_private_download": "https://files.slack.test/download/brief.pdf",
+                }
+            ]
+        },
+        has_text=True,
+    )
+
+    assert [item.name for item in preparation.attachments] == ["brief.pdf"]
+    request = mock_urlopen.call_args.args[0]
+    assert request.headers["Authorization"] == "Bearer token"
+    assert preparation.errors == []
+
+
 @patch("kage.connectors.telegram.urllib.request.urlopen")
 def test_telegram_send_message_uploads_photo_attachments(mock_urlopen, tmp_path):
     config = TelegramConnectorConfig(bot_token="123456:ABC", chat_id="789")
@@ -597,3 +908,65 @@ def test_telegram_send_message_uploads_large_png_as_document(mock_urlopen, tmp_p
     assert [item.name for item in delivery.skipped_attachments] == []
     assert delivery.errors == []
     assert mock_urlopen.call_args.args[0].full_url.endswith("/sendDocument")
+
+
+@patch("kage.connectors.telegram.urllib.request.urlopen")
+def test_telegram_prepare_incoming_attachments_downloads_document_and_photo(
+    mock_urlopen, tmp_path
+):
+    config = TelegramConnectorConfig(bot_token="123456:ABC", chat_id="789")
+    connector = TelegramConnector("test_telegram", config)
+
+    document_meta_response = MagicMock()
+    document_meta_response.__enter__.return_value = document_meta_response
+    document_meta_response.read.return_value = json.dumps(
+        {"ok": True, "result": {"file_path": "documents/spec.txt"}}
+    ).encode("utf-8")
+
+    photo_meta_response = MagicMock()
+    photo_meta_response.__enter__.return_value = photo_meta_response
+    photo_meta_response.read.return_value = json.dumps(
+        {"ok": True, "result": {"file_path": "photos/image.jpg"}}
+    ).encode("utf-8")
+
+    document_download = MagicMock()
+    document_download.__enter__.return_value = document_download
+    document_download.read.return_value = b"telegram document"
+
+    photo_download = MagicMock()
+    photo_download.__enter__.return_value = photo_download
+    photo_download.read.return_value = b"telegram photo"
+
+    def side_effect(request):
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        if "file_id=DOC1" in url:
+            return document_meta_response
+        if "file_id=P2" in url:
+            return photo_meta_response
+        if url.endswith("/documents/spec.txt"):
+            return document_download
+        if url.endswith("/photos/image.jpg"):
+            return photo_download
+        raise AssertionError(f"Unexpected Telegram URL: {url}")
+
+    mock_urlopen.side_effect = side_effect
+
+    preparation = connector._prepare_incoming_attachments(
+        tmp_path / "artifacts",
+        {
+            "document": {"file_id": "DOC1", "file_name": "spec.txt"},
+            "photo": [
+                {"file_id": "P1", "file_size": 10},
+                {"file_id": "P2", "file_size": 20},
+            ],
+        },
+        has_text=True,
+    )
+
+    assert [item.name for item in preparation.attachments] == [
+        "spec.txt",
+        "telegram-photo.jpg",
+    ]
+    assert preparation.errors == []
+    assert "file_id=DOC1" in mock_urlopen.call_args_list[0].args[0].full_url
+    assert "file_id=P2" in mock_urlopen.call_args_list[2].args[0].full_url


### PR DESCRIPTION
## Summary
- download incoming connector attachments into `KAGE_ARTIFACT_DIR/incoming` for connector poll runs
- add incoming attachment context to the prompt and run metadata so providers can choose whether to inspect those files
- support attachment-only Discord, Slack, and Telegram messages, and reply with a download failure notice when every incoming attachment fails

## Testing
- `uvx ruff format .`
- `uvx ruff check . --fix`
- `uv run pytest`

## Release
- Applying `release:patch` intentionally because this is a backward-compatible fix for missing connector attachment handling rather than a breaking or opt-in interface change.