### PR TITLE
Add task suspension controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ kage --install-completion
 
 Reload your shell after installation (`exec $SHELL -l`).
 
-Shell completion also suggests task names and recent run IDs for positional arguments like `kage run <task>`, `kage compile <task>`, `kage logs [<task>]`, `kage task run <name>`, and `kage runs show <exec_id>`.
+Shell completion also suggests task names and recent run IDs for positional arguments like `kage run <task>`, `kage compile <task>`, `kage logs [<task>]`, `kage task run <name>`, `kage task suspend <name>`, `kage task resume <name>`, and `kage runs show <exec_id>`.
 `kage doctor` also reports whether bash/zsh completion scripts are installed.
 
 ## Use Cases
@@ -144,6 +144,15 @@ You are conducting a systematic evaluation of free/open-source OCR solutions for
 ```
 
 `working_dir` is optional. Absolute paths are used as-is; relative paths are resolved from the task file directory (`.kage/tasks/`).
+
+To pause a task without disabling it, use suspension metadata or the CLI:
+
+```yaml
+suspended_until: "2026-05-09T18:30:00+09:00"
+suspended_reason: "Vacation for 2 weeks"
+```
+
+`kage task suspend <name> --for 2w --reason "Vacation"` writes those fields for you. `--for` accepts one token with `m`, `h`, `d`, or `w`; `--until` accepts an ISO date or datetime. Date-only values resume at midnight in the task timezone. Suspended tasks are skipped by cron and by manual `kage run`; use `kage run <task> --force` or `kage task run <task> --force` to run one intentionally.
 
 When you wake up:
 ```
@@ -231,7 +240,7 @@ Cleanup old logs every midnight.
 |---------|-------------|
 | `kage onboard` | Global setup (cron, directories, DB) |
 | `kage init` | Initialize kage in the current directory |
-| `kage run <task>` | Run a specific task immediately |
+| `kage run <task>` | Run a specific task immediately; add `--force` to bypass suspension |
 | `kage compile <task>` | Compile a prompt task into a sibling `.lock.sh` override |
 | `kage runs` | List execution runs in a status-colored table with relative time |
 | `kage runs show <exec_id>` | Show run metadata, paths, and status details |
@@ -242,7 +251,9 @@ Cleanup old logs every midnight.
 | `kage cron install` | Register to system scheduler |
 | `kage cron status` | Check background status |
 | `kage task list` | List tasks with status, effective type, and provider/command |
-| `kage task show <name>` | Show detailed task configuration and prompt hash |
+| `kage task show <name>` | Show detailed task configuration, suspension state, and prompt hash |
+| `kage task suspend <name> --for 2w` | Suspend future starts without changing `active` |
+| `kage task resume <name>` | Remove suspension metadata without starting the task |
 | `kage connector list` | List all configured connectors |
 | `kage connector setup <type>` | Show setup guide for a connector (discord, slack, telegram) |
 | `kage connector poll` | Manually poll connectors with `poll = true` |
@@ -263,6 +274,8 @@ On macOS, `kage` uses `launchd` instead of `cron`. You can further customize its
 If a prompt task has a sibling compiled lock such as `.kage/tasks/nightly.lock.sh`, kage executes that lock instead of the prompt body only while its stored `prompt_hash` still matches the current prompt body. When the prompt changes, the lock becomes stale and you need to run `kage compile <task>` again. `kage doctor`, `kage task list`, and the UI task cards all show whether a lock is fresh, stale, or missing. `kage task show <name>` also prints the current prompt hash so you can inspect what the lock should match.
 
 `kage task list` shortens the project column to the leaf directory name, shows prompt tasks as `Prompt` or `Prompt (Compiled)`, and resolves inherited providers as values like `gemini (Inherited)` so you can see what will actually run. Built-in `codex` runs now use `codex exec --yolo ...` in the default command template.
+
+Suspension is separate from `active`: `active: false` disables a task, while `suspended_until` only blocks new starts until the deadline expires. Invalid `suspended_until` values fail closed, so the task is skipped until you fix the value or run `kage task resume <name>`.
 
 Connector polling replies are recorded in the same run history. Use `kage runs --source connector_poll` to isolate them, then inspect the raw AI CLI output with `kage logs --run <exec_id>`.
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -97,7 +97,7 @@ kage --install-completion
 
 設定後はシェルを再読み込みしてください（`exec $SHELL -l`）。
 
-シェル補完では `kage run <task>`、`kage compile <task>`、`kage logs [<task>]`、`kage task run <name>`、`kage runs show <exec_id>` のような位置引数に対して task 名や最近の run id も候補に出ます。
+シェル補完では `kage run <task>`、`kage compile <task>`、`kage logs [<task>]`、`kage task run <name>`、`kage task suspend <name>`、`kage task resume <name>`、`kage runs show <exec_id>` のような位置引数に対して task 名や最近の run id も候補に出ます。
 `kage doctor` でも bash / zsh の completion script が入っているか確認できます。
 
 ## ユースケース
@@ -144,6 +144,15 @@ working_dir: ../../benchmark
 ```
 
 `working_dir` は任意です。絶対パスはそのまま使われ、相対パスは task file が置かれているディレクトリ（`.kage/tasks/`）基準で解決されます。
+
+task を無効化せず一時停止する場合は、suspension metadata か CLI を使います。
+
+```yaml
+suspended_until: "2026-05-09T18:30:00+09:00"
+suspended_reason: "2週間の休暇"
+```
+
+`kage task suspend <name> --for 2w --reason "Vacation"` はこれらの field を task file の front matter に書き込みます。`--for` は `m`, `h`, `d`, `w` のいずれか 1 token、`--until` は ISO date / datetime を受け付けます。日付だけを指定した場合は task timezone の午前 0 時に再開します。停止中の task は cron と手動 `kage run` のどちらでも skip され、意図的に 1 回だけ実行する場合は `kage run <task> --force` または `kage task run <task> --force` を使います。
 
 朝起きた時:
 ```
@@ -231,7 +240,7 @@ shell: "bash"
 |---------|-------------|
 | `kage onboard` | グローバルセットアップ |
 | `kage init` | 現在のディレクトリに kage を初期化 |
-| `kage run <task>` | 特定 task を即時実行 |
+| `kage run <task>` | 特定 task を即時実行。停止中 task は `--force` で実行 |
 | `kage compile <task>` | prompt task から同名の `.lock.sh` override を生成 |
 | `kage runs` | 相対日時付きの色付きテーブルで実行履歴を表示 |
 | `kage runs show <exec_id>` | 実行メタデータ、状態、ログパスを表示 |
@@ -242,7 +251,9 @@ shell: "bash"
 | `kage cron install` | システムスケジューラーに登録 |
 | `kage cron status` | バックグラウンド実行状態の確認 |
 | `kage task list` | 状態、実効 Type、Provider/Command 付きでタスク一覧を表示 |
-| `kage task show <name>` | 詳細設定と prompt hash を表示 |
+| `kage task show <name>` | 詳細設定、停止状態、prompt hash を表示 |
+| `kage task suspend <name> --for 2w` | `active` を変えずに future starts を一時停止 |
+| `kage task resume <name>` | task を即時実行せず suspension metadata だけ削除 |
 | `kage connector list` | 設定済みのコネクター一覧を表示 |
 | `kage connector setup <type>` | コネクター（discord, slack, telegram）のセットアップガイドを表示 |
 | `kage connector poll` | `poll = true` のコネクターを即座にポーリング |
@@ -262,6 +273,8 @@ macOS では `cron` の代わりに `launchd` が使用されます。`config.to
 prompt task と同名の compiled lock 例えば `.kage/tasks/nightly.lock.sh` が存在する場合、kage はその lock に保持された `prompt_hash` が現在の prompt 本文と一致している間だけ Markdown 本文の代わりにそれを実行します。prompt 本文を更新したら lock は stale 扱いになるので、`kage compile <task>` を再実行してください。`kage doctor`、`kage task list`、UI の task card でも fresh / stale / missing を確認できます。`kage task show <name>` では現在の prompt hash も確認できます。
 
 `kage task list` では project 列は末尾ディレクトリ名だけを表示し、prompt task は `Prompt` または `Prompt (Compiled)` として見えます。provider 未指定でも `gemini (Inherited)` のように実際に使われる provider を表示します。built-in の `codex` 実行テンプレートは既定で `codex exec --yolo ...` を使います。
+
+suspension は `active` とは別の状態です。`active: false` は task を無効化し、`suspended_until` は deadline まで新規実行だけを止めます。不正な `suspended_until` は fail closed として扱われるため、値を直すか `kage task resume <name>` するまで task は skip されます。
 
 connector の `poll` 返信も同じ run 履歴に保存されます。`kage runs --source connector_poll` で絞り込み、`kage logs --run <exec_id>` で AI CLI の raw output を確認できます。
 

--- a/skills/kage/SKILL.md
+++ b/skills/kage/SKILL.md
@@ -14,6 +14,7 @@ description: Autonomous AI Project Agent & Cron Task Runner. Orchestrates repeti
 - **Hybrid Task Types**: AI-driven prompts (Markdown body) or direct shell commands (`command` front matter).
 - **Concurrency Control**: `allow`, `forbid` (skip if running), `replace` (kill old and restart).
 - **Time Windows**: `allowed_hours: "9-17"` or `denied_hours: "12"`.
+- **Task Suspension**: `suspended_until` pauses future starts without changing `active`.
 - **State Persistence**: `.kage/memory/{task}/{date}.json`.
 - **Connectors**: Integrate with Discord/Slack/Telegram for task notifications (always on) and optional bi-directional chat (`poll = true`).
 - **Layered Config**: `.kage/config.local.toml` > `.kage/config.toml` > `~/.kage/config.toml` > defaults.
@@ -22,7 +23,7 @@ description: Autonomous AI Project Agent & Cron Task Runner. Orchestrates repeti
 
 - `kage onboard` — Setup global directories and `kage cron`.
 - `kage init` — Initialize in current directory.
-- `kage run <task>` — Execute a specific task immediately.
+- `kage run <task>` — Execute a specific task immediately; add `--force` to bypass suspension.
 - `kage compile <task>` — Compile a prompt task into a sibling `.lock.sh` override.
 - `kage cron run` — Execute the scheduler loop once (used by cron/launchd).
 - `kage runs` — List execution runs in a relative-time table; add `--absolute-time` for detailed timestamps.
@@ -31,7 +32,10 @@ description: Autonomous AI Project Agent & Cron Task Runner. Orchestrates repeti
 - `kage logs [<task>]` — Open raw logs for the latest run of a task, or merge all task logs when omitted.
 - `kage logs --run <exec_id>` — Open raw logs for a specific run.
 - `kage task list` — List tasks with short project names, effective type, and provider/command.
-- `kage task show <name>` — Detailed task configuration, including the current prompt hash.
+- `kage task show <name>` — Detailed task configuration, suspension state, and current prompt hash.
+- `kage task suspend <name> --for 2w --reason "Vacation"` — Pause future starts without disabling the task.
+- `kage task suspend <name> --until 2026-05-09` — Pause until an ISO date/datetime; date-only resumes at task-local midnight.
+- `kage task resume <name>` — Remove suspension metadata without starting the task.
 - `kage connector list` — List all configured connectors.
 - `kage connector setup <type>` — Show setup guide for a connector (discord, slack, telegram).
 - `kage connector poll` — Manually trigger polling for all connectors.
@@ -40,11 +44,13 @@ description: Autonomous AI Project Agent & Cron Task Runner. Orchestrates repeti
 - `kage ui` — Open web dashboard.
 - `kage tui` — Open the Textual terminal dashboard with logs, tasks, connectors, and settings tabs.
 
-Shell completion covers positional task/run arguments as well, so `kage run <task>`, `kage compile <task>`, `kage logs [<task>]`, `kage task run <name>`, `kage task show <name>`, `kage runs show <exec_id>`, and `kage stop <exec_id>` can all suggest concrete values after `kage completion install bash|zsh`. `kage doctor` reports whether those completion scripts are installed.
+Shell completion covers positional task/run arguments as well, so `kage run <task>`, `kage compile <task>`, `kage logs [<task>]`, `kage task run <name>`, `kage task show <name>`, `kage task suspend <name>`, `kage task resume <name>`, `kage runs show <exec_id>`, and `kage stop <exec_id>` can all suggest concrete values after `kage completion install bash|zsh`. `kage doctor` reports whether those completion scripts are installed.
 
 If a prompt task has a sibling compiled lock like `.kage/tasks/nightly.lock.sh`, kage executes that lock instead of the Markdown prompt body only while the stored `prompt_hash` still matches the current prompt body. If the prompt body changes, the lock becomes stale and must be regenerated with `kage compile <task>`. `kage doctor`, `kage task list`, and the UI all surface whether the lock is fresh, stale, or missing, and `kage task show <name>` prints the current prompt hash.
 
 In `kage task list`, prompt tasks render as `Prompt` or `Prompt (Compiled)`, stale compiled locks are highlighted, the project column uses only the leaf directory name, and inherited providers show up explicitly as values like `gemini (Inherited)`. The built-in `codex` command template runs `codex exec --yolo ...` by default.
+
+Suspension is separate from `active`: cron and normal manual runs skip a task while `suspended_until` is in the future, or while the value is invalid. Use `kage run <task> --force` or `kage task run <task> --force` for a deliberate one-off run. Connector-driven agents should use `kage task suspend` / `kage task resume` instead of editing `.kage/tasks/*.md` directly.
 
 Connector poll replies are recorded as normal runs. Use `kage runs --source connector_poll` to find them and `kage logs --run <exec_id>` to inspect raw AI CLI output.
 
@@ -66,6 +72,8 @@ working_dir: ../../workspace        # optional; relative to this task file, or a
 timezone: "Asia/Tokyo"              # e.g. "UTC", "Asia/Tokyo" (optional)
 allowed_hours: "9-17"               # e.g. "9-17,21" (optional)
 denied_hours: "0-5"                 # e.g. "0-5,12" (optional)
+suspended_until: "2026-05-09T18:30:00+09:00" # optional suspension deadline
+suspended_reason: "Vacation"        # optional suspension reason
 notify_connectors: ["discord"]      # list of connector names (optional)
 active: true
 ---

--- a/src/kage/ai/chat.py
+++ b/src/kage/ai/chat.py
@@ -168,6 +168,9 @@ You MUST NOT answer questions or provide information related to:
 2. Confidential insider information, trade secrets, or personal data found on this PC.
 3. Any root-level or critical system configuration files that could compromise security.
 If asked about these, politely decline, stating that it violates your security constraints as a local agent.
+
+[TASK CONTROL RULE]
+If the user asks to pause or resume a scheduled kage task, use `kage task suspend ...` or `kage task resume ...` instead of editing `.kage/tasks/*.md` directly.
 """
 
 

--- a/src/kage/default_config.toml
+++ b/src/kage/default_config.toml
@@ -106,6 +106,7 @@ Your task has a `mode` field that controls lifecycle behavior:
 - **Finish what you can NOW.** If the task (or remaining sub-tasks) can be completed in this run, do it all. Do NOT artificially limit yourself to one sub-task when you have capacity to do more. Only defer to a future run when the work genuinely cannot fit in a single execution.
 - **Be idempotent.** If re-run with the same state, produce the same result.
 - **DO NOT modify `.kage/tasks/*.md` files.** These are user-maintained task configurations. You are only allowed to manage `.kage/memory/` and project files.
+- **Use task control commands.** If the user asks to pause or resume a scheduled task, run `kage task suspend ...` or `kage task resume ...` instead of editing task front matter directly.
 - **Write files.** Save outputs (reports, code, data) to the project directory, not just to stdout.
 - **Update task.json.** Mark the current sub-task as `"done"` after completing it. If you complete multiple sub-tasks in one run, mark them ALL as `"done"`.
 - **Handle errors gracefully.** If something fails, record the error in memory and try the next sub-task on the next run.

--- a/src/kage/executor.py
+++ b/src/kage/executor.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import threading
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -41,6 +42,21 @@ from .runs import (
     infer_output_summary,
     write_run_metadata,
 )
+from .suspension import get_suspension_status, update_markdown_front_matter
+
+
+class TaskExecutionResult(str, Enum):
+    STARTED = "started"
+    SKIPPED_INACTIVE = "skipped_inactive"
+    SKIPPED_SUSPENDED = "skipped_suspended"
+    SKIPPED_CONCURRENCY = "skipped_concurrency"
+    FAILED_CONFIG = "failed_config"
+
+
+class LoggedCommandError(RuntimeError):
+    def __init__(self, message: str, *, started: bool):
+        super().__init__(message)
+        self.started = started
 
 
 def _normalize_headless_args(cmd: list[str]) -> list[str]:
@@ -200,12 +216,15 @@ def _compute_prompt_hash(prompt: str) -> str:
 def _deactivate_task(task_file: Path):
     if not task_file.exists():
         return
-    content = task_file.read_text(encoding="utf-8")
-    new_content = re.sub(r"active:\s*(true|false)", "active: false", content)
-    if content == new_content:
-        # active が無い場合は cron: の後に追加
-        new_content = re.sub(r"(cron:.*?\n)", r"\1active: false\n", content)
-    task_file.write_text(new_content, encoding="utf-8")
+    if task_file.suffix.lower() == ".md":
+        update_markdown_front_matter(task_file, updates={"active": False})
+    else:
+        content = task_file.read_text(encoding="utf-8")
+        new_content = re.sub(r"active:\s*(true|false)", "active: false", content)
+        if content == new_content:
+            # active が無い場合は cron: の後に追加
+            new_content = re.sub(r"(cron:.*?\n)", r"\1active: false\n", content)
+        task_file.write_text(new_content, encoding="utf-8")
     print(f"Task deactivated: {task_file.name}")
 
 
@@ -394,28 +413,41 @@ def run_logged_command(
     exec_id: str,
     timeout: float | None = None,
 ) -> dict:
-    proc = subprocess.Popen(
-        cmd,
-        cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env,
-        start_new_session=True,
-    )
-
-    set_execution_pid(exec_id, proc.pid)
-
-    stream_state = _stream_process_output(proc, exec_id)
     try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            start_new_session=True,
+        )
+        set_execution_pid(exec_id, proc.pid)
+        stream_state = _stream_process_output(proc, exec_id)
         returncode = proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
         proc.wait()
         raise
+    except Exception as exc:
+        if "proc" in locals():
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+            raise LoggedCommandError(str(exc), started=True) from exc
+        raise
     finally:
-        for thread in stream_state["threads"]:
-            thread.join()
+        if "stream_state" in locals():
+            for thread in stream_state["threads"]:
+                thread.join()
 
     return {
         "returncode": returncode,
@@ -471,10 +503,35 @@ def stop_execution(exec_id: str):
         print(f"Failed to stop execution {exec_id}: {e}")
 
 
-def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = None):
+def execute_task(
+    project_dir: Path,
+    task: TaskDef,
+    task_file: Optional[Path] = None,
+    *,
+    force: bool = False,
+) -> TaskExecutionResult:
     if not task.active:
         print(f"Skipping inactive task '{task.name}' in {project_dir}")
-        return
+        return TaskExecutionResult.SKIPPED_INACTIVE
+
+    if task.suspended_until is not None and not force:
+        global_config_for_suspension = get_global_config(workspace_dir=project_dir)
+        suspension = get_suspension_status(
+            task,
+            tz_name=task.timezone or global_config_for_suspension.timezone,
+        )
+        if suspension.is_suspended:
+            if suspension.is_invalid:
+                print(
+                    f"Skipping suspended task '{task.name}' in {project_dir}: "
+                    f"invalid suspended_until ({suspension.raw_until})"
+                )
+            else:
+                print(
+                    f"Skipping suspended task '{task.name}' in {project_dir}: "
+                    f"{suspension.summary}"
+                )
+            return TaskExecutionResult.SKIPPED_SUSPENDED
 
     from .config import get_system_prompt
     from .parser import ConcurrencyPolicy, ExecutionMode
@@ -488,7 +545,7 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
             print(
                 f"Task '{task.name}' is already running (PID: {running_pid}). Skipping."
             )
-            return
+            return TaskExecutionResult.SKIPPED_CONCURRENCY
         elif task.concurrency_policy == ConcurrencyPolicy.REPLACE:
             print(
                 f"Task '{task.name}' is already running (PID: {running_pid}). Terminating and replacing."
@@ -505,6 +562,7 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
     exec_id: str | None = None
     artifact_staging_dir: Path | None = None
     attachments: list[ConnectorAttachment] = []
+    command_started = False
 
     # ロックファイル作成
     try:
@@ -591,7 +649,7 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                 msg = "AIエンジンが未指定です。"
                 print(f"[kage] ERROR: {msg}")
                 log_execution(str(project_dir), task.name, "FAILED", "", msg)
-                return
+                return TaskExecutionResult.FAILED_CONFIG
 
             # プロンプトの構築: System Prompt + Task Plan + Memory + Task Instructions
             thinking_tag = get_thinking_tag(engine_name)
@@ -625,7 +683,7 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                 "",
                 "No prompt or command specified",
             )
-            return
+            return TaskExecutionResult.FAILED_CONFIG
 
         try:
             from .db import init_db
@@ -730,7 +788,9 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                     exec_id=exec_id,
                     timeout=timeout,
                 )
+                command_started = True
             except subprocess.TimeoutExpired:
+                command_started = True
                 if artifact_staging_dir is not None:
                     attachments = collect_artifacts_from_dir(
                         artifact_staging_dir,
@@ -752,7 +812,7 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                 write_artifact_metadata(exec_id, artifact_staging_dir, attachments)
 
             if get_execution_status(exec_id) == "STOPPED":
-                return
+                return TaskExecutionResult.STARTED
 
             # autostop チェック: task.json の sub_tasks が全て done の場合
             if prompt_execution and task.mode == ExecutionMode.AUTOSTOP and task_file:
@@ -837,6 +897,13 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                     attachments=attachments,
                 )
         except Exception as e:
+            if isinstance(e, LoggedCommandError) and e.started:
+                command_started = True
+            elif exec_id and get_execution_pid(exec_id) is not None:
+                command_started = True
+            if exec_id is None:
+                print(f"[kage] ERROR before execution start: {e}")
+                return TaskExecutionResult.FAILED_CONFIG
             if exec_id and artifact_staging_dir is not None and not attachments:
                 attachments = collect_artifacts_from_dir(
                     artifact_staging_dir,
@@ -858,6 +925,8 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                     run_id=exec_id,
                     attachments=attachments,
                 )
+            if not command_started:
+                return TaskExecutionResult.FAILED_CONFIG
     finally:
         if lock_path.exists():
             lock_path.unlink()
@@ -868,3 +937,4 @@ def execute_task(project_dir: Path, task: TaskDef, task_file: Optional[Path] = N
                 set_execution_pid(exec_id, None)
         except Exception:
             pass
+    return TaskExecutionResult.STARTED

--- a/src/kage/main.py
+++ b/src/kage/main.py
@@ -136,6 +136,27 @@ def _task_type_label(task, compiled_state: str | None = None) -> str:
     return "Shell"
 
 
+def _suspension_table_value(status) -> str:
+    if status.is_invalid:
+        return "[red]invalid[/red]"
+    if status.is_suspended and status.until:
+        return f"[yellow]until {status.until.isoformat(timespec='seconds')}[/yellow]"
+    if status.raw_until:
+        return "[dim]expired[/dim]"
+    return "-"
+
+
+def _execution_result_message(result) -> str:
+    result_value = getattr(result, "value", str(result))
+    messages = {
+        "skipped_inactive": "task is inactive",
+        "skipped_suspended": "task is suspended",
+        "skipped_concurrency": "task is already running",
+        "failed_config": "task configuration is incomplete",
+    }
+    return messages.get(result_value, "task did not start")
+
+
 def _task_completion_items(incomplete: str) -> list[CompletionItem]:
     from .parser import load_project_tasks
     from .scheduler import get_projects
@@ -623,6 +644,7 @@ def task_list(
     table.add_column("Project", style="dim")
     table.add_column("Task Name", style="bold")
     table.add_column("Active")
+    table.add_column("Suspended")
     table.add_column("Schedule")
     table.add_column("Type")
     table.add_column("Provider/Command")
@@ -652,10 +674,17 @@ def task_list(
                 task_type = _task_type_label(t)
                 provider_info = (t.command or "")[:40]
             status = "[green]ON[/green]" if t.active else "[red]OFF[/red]"
+            from .suspension import get_suspension_status
+
+            suspension = get_suspension_status(
+                t,
+                tz_name=t.timezone or merged_cfg.timezone,
+            )
             table.add_row(
                 _project_short_name(str(proj_dir)),
                 t.name,
                 status,
+                _suspension_table_value(suspension),
                 t.cron,
                 task_type,
                 provider_info or "-",
@@ -756,8 +785,8 @@ We need to select the best free OCR model for extracting text from PDFs. Please 
 def _set_task_active_state(name: Optional[str], active: bool, all_tasks: bool = False):
     from .scheduler import get_projects
     from .parser import load_project_tasks
+    from .suspension import update_task_file_metadata
     from rich.console import Console
-    import re
 
     console = Console()
     projects = get_projects()
@@ -769,23 +798,11 @@ def _set_task_active_state(name: Optional[str], active: bool, all_tasks: bool = 
             t = local_task.task
             if all_tasks or t.name == name:
                 found_any = True
-                # ファイルを直接書き換える
-                content = task_file.read_text(encoding="utf-8")
-
-                # Markdown の Front Matter を書き換える
-                # シンプルに正規表現で active: ... を置換
-                new_val = "true" if active else "false"
-                if "active:" in content:
-                    content = re.sub(
-                        r"active:\s*(true|false)", f"active: {new_val}", content
-                    )
-                else:
-                    # active が無い場合は cron: の後に追加
-                    content = re.sub(
-                        r"(cron:.*?\n)", rf"\1active: {new_val}\n", content
-                    )
-
-                task_file.write_text(content, encoding="utf-8")
+                update_task_file_metadata(
+                    task_file,
+                    task_name=t.name,
+                    updates={"active": active},
+                )
                 state_str = (
                     "[green]ENABLED[/green]" if active else "[red]DISABLED[/red]"
                 )
@@ -828,6 +845,103 @@ def task_off(
     _set_task_active_state(name, False, all_tasks)
 
 
+@task_app.command("suspend")
+def task_suspend(
+    name: str = typer.Argument(
+        ...,
+        help="Task name to suspend",
+        autocompletion=_complete_task_names,
+    ),
+    for_duration: Optional[str] = typer.Option(
+        None,
+        "--for",
+        help="Suspend for one duration token: 30m, 3h, 14d, or 2w",
+    ),
+    until: Optional[str] = typer.Option(
+        None,
+        "--until",
+        help="Suspend until an ISO date or datetime",
+    ),
+    reason: Optional[str] = typer.Option(
+        None,
+        "--reason",
+        help="Optional reason stored in task front matter",
+    ),
+    project: Optional[str] = typer.Option(
+        None, "--project", "-p", help="Project path substring for task lookup"
+    ),
+):
+    """Suspend a task until a deadline without changing its active state."""
+    from .config import get_global_config
+    from .suspension import (
+        parse_suspension_deadline,
+        suspension_deadline_from_duration,
+        update_task_file_metadata,
+    )
+    from rich.console import Console
+
+    if bool(for_duration) == bool(until):
+        typer.echo("Specify exactly one of --for or --until.")
+        raise typer.Exit(1)
+
+    console = Console()
+    proj_dir, task_file, task = _resolve_named_task(name, project=project)
+
+    cfg = get_global_config(workspace_dir=proj_dir)
+    task_tz = task.timezone or cfg.timezone
+    try:
+        deadline = (
+            suspension_deadline_from_duration(for_duration, tz_name=task_tz)
+            if for_duration
+            else parse_suspension_deadline(until or "", tz_name=task_tz)
+        )
+    except ValueError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(1) from exc
+
+    updates = {"suspended_until": deadline.isoformat(timespec="seconds")}
+    remove_keys: set[str] = set()
+    if reason is not None and reason.strip():
+        updates["suspended_reason"] = reason
+    elif reason is not None:
+        remove_keys.add("suspended_reason")
+
+    update_task_file_metadata(
+        task_file,
+        task_name=task.name,
+        updates=updates,
+        remove_keys=remove_keys,
+    )
+    console.print(
+        f"[yellow]SUSPENDED[/yellow]: {task.name} until {updates['suspended_until']} ({task_file})"
+    )
+
+
+@task_app.command("resume")
+def task_resume(
+    name: str = typer.Argument(
+        ...,
+        help="Task name to resume",
+        autocompletion=_complete_task_names,
+    ),
+    project: Optional[str] = typer.Option(
+        None, "--project", "-p", help="Project path substring for task lookup"
+    ),
+):
+    """Remove task suspension metadata without starting the task."""
+    from .suspension import update_task_file_metadata
+    from rich.console import Console
+
+    console = Console()
+    _proj_dir, task_file, task = _resolve_named_task(name, project=project)
+    update_task_file_metadata(
+        task_file,
+        task_name=task.name,
+        remove_keys={"suspended_until", "suspended_reason"},
+    )
+    console.print(f"[green]RESUMED[/green]: {task.name} ({task_file})")
+
+
 @task_app.command("show")
 def task_show(
     name: str = typer.Argument(
@@ -842,11 +956,17 @@ def task_show(
     """Show detailed task configuration, including compiled lock freshness and prompt hash."""
     from .compiler import compiled_task_status, prompt_hash
     from .config import get_global_config
+    from .suspension import get_suspension_status
     from rich.console import Console
     from rich.panel import Panel
 
     console = Console()
     proj_dir, task_file, task = _resolve_named_task(name, project=project)
+    merged_cfg = get_global_config(workspace_dir=proj_dir)
+    suspension = get_suspension_status(
+        task,
+        tz_name=task.timezone or merged_cfg.timezone,
+    )
     details = [
         f"[bold]Name:[/bold]           {task.name}",
         f"[bold]Schedule:[/bold]       {task.cron}",
@@ -855,12 +975,13 @@ def task_show(
         f"[bold]Timezone:[/bold]       {task.timezone or 'global'}",
         f"[bold]Allowed Hours:[/bold]  {task.allowed_hours or 'any'}",
         f"[bold]Denied Hours:[/bold]   {task.denied_hours or 'none'}",
+        f"[bold]Suspension:[/bold]     {suspension.summary}",
+        f"[bold]Suspend Reason:[/bold] {task.suspended_reason or '-'}",
         f"[bold]Project:[/bold]        {proj_dir}",
         f"[bold]File:[/bold]           {task_file}",
     ]
     compiled = compiled_task_status(task, task_file)
     if task.prompt:
-        merged_cfg = get_global_config(workspace_dir=proj_dir)
         compiled_state = (
             "fresh"
             if compiled and compiled["exists"] and compiled["is_fresh"]
@@ -910,15 +1031,39 @@ def task_run(
     project: Optional[str] = typer.Option(
         None, "--project", "-p", help="Project path substring for task lookup"
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Run even when the task is currently suspended",
+    ),
 ):
-    """Run a specific task immediately (ignores schedule)."""
-    from .executor import execute_task
+    """Run a specific task immediately (ignores schedule, but not suspension unless forced)."""
+    from .config import get_global_config
+    from .executor import TaskExecutionResult, execute_task
+    from .suspension import get_suspension_status
     from rich.console import Console
 
     console = Console()
     proj_dir, task_file, task = _resolve_named_task(name, project=project)
+    if not force:
+        cfg = get_global_config(workspace_dir=proj_dir)
+        suspension = get_suspension_status(
+            task,
+            tz_name=task.timezone or cfg.timezone,
+        )
+        if suspension.is_suspended:
+            console.print(
+                f"[yellow]Task '{name}' is suspended:[/yellow] {suspension.summary}"
+            )
+            raise typer.Exit(1)
+
     console.print(f"[cyan]Running task:[/cyan] [bold]{name}[/bold] in {proj_dir}")
-    execute_task(proj_dir, task, task_file=task_file)
+    result = execute_task(proj_dir, task, task_file=task_file, force=force)
+    if result != TaskExecutionResult.STARTED:
+        console.print(
+            f"[yellow]Task '{name}' did not start:[/yellow] {_execution_result_message(result)}"
+        )
+        raise typer.Exit(1)
     console.print(f"[green]✓ Task '{name}' completed.[/green]")
 
 
@@ -1020,9 +1165,14 @@ def run(
     project: Optional[str] = typer.Option(
         None, "--project", "-p", help="Project path substring for task lookup"
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Run even when the task is currently suspended",
+    ),
 ):
     """Run a specific task immediately."""
-    task_run(name=name, project=project)
+    task_run(name=name, project=project, force=force)
 
 
 @app.command()
@@ -1411,6 +1561,7 @@ def doctor():
     from croniter import croniter
     from rich.console import Console
     from rich.table import Table
+    from .suspension import parse_suspension_deadline
     from .config import (
         get_global_config,
         KAGE_GLOBAL_DIR,
@@ -1671,6 +1822,8 @@ def doctor():
             "timeout_minutes",
             "allowed_hours",
             "denied_hours",
+            "suspended_until",
+            "suspended_reason",
             "command",
             "shell",
             "working_dir",
@@ -1714,6 +1867,21 @@ def doctor():
             task_data.get("working_dir"), str
         ):
             fail(label, "working_dir must be string")
+        if task_data.get("suspended_until") is not None:
+            if not isinstance(task_data["suspended_until"], str):
+                fail(label, "suspended_until must be string")
+            else:
+                try:
+                    parse_suspension_deadline(
+                        task_data["suspended_until"],
+                        tz_name=task_data.get("timezone") or merged_cfg.timezone,
+                    )
+                except ValueError as exc:
+                    warn(label, str(exc))
+        if task_data.get("suspended_reason") is not None and not isinstance(
+            task_data["suspended_reason"], str
+        ):
+            fail(label, "suspended_reason must be string")
 
         command_template = task_data.get("command_template")
         if command_template is not None and (
@@ -1788,6 +1956,8 @@ def doctor():
             "timeout_minutes",
             "allowed_hours",
             "denied_hours",
+            "suspended_until",
+            "suspended_reason",
             "provider",
             "command",
             "shell",
@@ -1822,6 +1992,12 @@ def doctor():
             "name": fm.get("name"),
             "cron": fm.get("cron"),
             "active": fm.get("active", "true"),
+            "mode": fm.get("mode"),
+            "concurrency_policy": fm.get("concurrency_policy"),
+            "timezone": fm.get("timezone"),
+            "timeout_minutes": fm.get("timeout_minutes"),
+            "allowed_hours": fm.get("allowed_hours"),
+            "denied_hours": fm.get("denied_hours"),
             "prompt": body if body.strip() else None,
             "command": fm.get("command", "").strip()
             if isinstance(fm.get("command"), str)
@@ -1831,6 +2007,8 @@ def doctor():
             "provider": fm.get("provider"),
             "parser": fm.get("parser"),
             "parser_args": fm.get("parser_args"),
+            "suspended_until": fm.get("suspended_until"),
+            "suspended_reason": fm.get("suspended_reason"),
             "connector": fm.get("connector"),
             "connectors": fm.get("connectors"),
             "notify_connectors": fm.get("notify_connectors"),

--- a/src/kage/parser.py
+++ b/src/kage/parser.py
@@ -36,6 +36,13 @@ class TaskDef(BaseModel):
     denied_hours: Optional[str] = pydantic.Field(
         default=None, description="実行を禁止する時間帯（例: '0-5,12'）"
     )
+    suspended_until: Optional[str] = pydantic.Field(
+        default=None,
+        description="この日時までタスクの新規実行を停止する（ISO date/datetime）",
+    )
+    suspended_reason: Optional[str] = pydantic.Field(
+        default=None, description="タスク停止の理由"
+    )
     notify_connectors: Optional[list[str]] = pydantic.Field(
         default=None,
         description="実行完了時に結果を通知するコネクター名のリスト（例: ['discord']）",
@@ -228,6 +235,8 @@ def parse_task_file(filepath: Path) -> List[tuple[str, TaskDef]]:
             else None,
             "allowed_hours": fm.get("allowed_hours"),
             "denied_hours": fm.get("denied_hours"),
+            "suspended_until": fm.get("suspended_until"),
+            "suspended_reason": fm.get("suspended_reason"),
             "command": command,
             "shell": fm.get("shell"),
             "working_dir": fm.get("working_dir"),

--- a/src/kage/scheduler.py
+++ b/src/kage/scheduler.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from .config import KAGE_PROJECTS_LIST, get_global_config
 from .parser import load_project_tasks, TaskDef
 from .executor import execute_task
+from .suspension import get_suspension_status
 
 
 def get_projects() -> list[Path]:
@@ -104,9 +105,11 @@ def run_all_scheduled_tasks():
     now = datetime.now(dt_timezone.utc)
     projects = get_projects()
     cfg = get_global_config()
-    tz_name = cfg.timezone
+    default_tz_name = cfg.timezone
 
     for proj_dir in projects:
+        project_cfg = get_global_config(workspace_dir=proj_dir)
+        tz_name = project_cfg.timezone or default_tz_name
         tasks = load_project_tasks(proj_dir)
         for toml_file, local_task in tasks:
             t = local_task.task
@@ -115,6 +118,15 @@ def run_all_scheduled_tasks():
 
             # タスク固有のタイムゾーン、なければグローバル
             task_tz = t.timezone or tz_name
+
+            suspension = get_suspension_status(t, now=now, tz_name=task_tz)
+            if suspension.is_suspended:
+                if suspension.is_invalid:
+                    print(
+                        f"Skipping task '{t.name}' in {proj_dir}: "
+                        f"invalid suspended_until ({suspension.raw_until})"
+                    )
+                continue
 
             # 時間帯枠のチェック
             if not is_within_time_window(t, now, task_tz):

--- a/src/kage/suspension.py
+++ b/src/kage/suspension.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone as dt_timezone
+import json
+import re
+from pathlib import Path
+from typing import Any
+import zoneinfo
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DURATION_RE = re.compile(r"^([1-9]\d*)([mhdw])$")
+_FRONT_MATTER_LINE_RE = re.compile(
+    r"^(\s*)([A-Za-z_][A-Za-z0-9_-]*)(\s*:\s*)(.*?)(\r?\n)?$"
+)
+_DURATION_UNITS = {
+    "m": "minutes",
+    "h": "hours",
+    "d": "days",
+    "w": "weeks",
+}
+
+
+@dataclass(frozen=True)
+class SuspensionStatus:
+    raw_until: str | None
+    reason: str | None
+    until: datetime | None = None
+    is_suspended: bool = False
+    is_invalid: bool = False
+    error: str | None = None
+
+    @property
+    def summary(self) -> str:
+        if not self.raw_until:
+            return "-"
+        if self.is_invalid:
+            return f"invalid: {self.raw_until}"
+        if self.until is None:
+            return "-"
+        prefix = "until" if self.is_suspended else "expired"
+        return f"{prefix}: {self.until.isoformat(timespec='seconds')}"
+
+
+def _resolve_timezone(tz_name: str | None) -> dt_timezone | zoneinfo.ZoneInfo:
+    if not tz_name:
+        return dt_timezone.utc
+    try:
+        return zoneinfo.ZoneInfo(tz_name)
+    except zoneinfo.ZoneInfoNotFoundError:
+        return dt_timezone.utc
+
+
+def _aware_now(now: datetime | None = None) -> datetime:
+    if now is None:
+        return datetime.now(dt_timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=dt_timezone.utc)
+    return now
+
+
+def parse_suspension_duration(value: str) -> timedelta:
+    token = value.strip()
+    match = _DURATION_RE.fullmatch(token)
+    if not match:
+        raise ValueError("duration must be one token like 30m, 3h, 14d, or 2w")
+    amount = int(match.group(1))
+    unit = match.group(2)
+    return timedelta(**{_DURATION_UNITS[unit]: amount})
+
+
+def suspension_deadline_from_duration(
+    value: str,
+    *,
+    now: datetime | None = None,
+    tz_name: str | None = None,
+) -> datetime:
+    tz = _resolve_timezone(tz_name)
+    local_now = _aware_now(now).astimezone(tz)
+    deadline_utc = local_now.astimezone(dt_timezone.utc) + parse_suspension_duration(
+        value
+    )
+    return deadline_utc.astimezone(tz)
+
+
+def parse_suspension_deadline(
+    value: str,
+    *,
+    tz_name: str | None = None,
+) -> datetime:
+    raw = value.strip()
+    if not raw:
+        raise ValueError("suspended_until must not be empty")
+
+    tz = _resolve_timezone(tz_name)
+    if _DATE_RE.fullmatch(raw):
+        parsed_date = date.fromisoformat(raw)
+        return datetime(
+            parsed_date.year,
+            parsed_date.month,
+            parsed_date.day,
+            tzinfo=tz,
+        )
+
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"invalid suspended_until: {value}") from exc
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=tz)
+    return parsed
+
+
+def get_suspension_status(
+    task: Any,
+    *,
+    now: datetime | None = None,
+    tz_name: str | None = None,
+) -> SuspensionStatus:
+    raw_until = getattr(task, "suspended_until", None)
+    reason = getattr(task, "suspended_reason", None)
+    if raw_until is None:
+        return SuspensionStatus(raw_until=None, reason=reason)
+
+    effective_tz = getattr(task, "timezone", None) or tz_name
+    try:
+        until = parse_suspension_deadline(str(raw_until), tz_name=effective_tz)
+    except ValueError as exc:
+        return SuspensionStatus(
+            raw_until=str(raw_until),
+            reason=reason,
+            is_suspended=True,
+            is_invalid=True,
+            error=str(exc),
+        )
+
+    local_now = _aware_now(now).astimezone(until.tzinfo or dt_timezone.utc)
+    return SuspensionStatus(
+        raw_until=str(raw_until),
+        reason=reason,
+        until=until,
+        is_suspended=local_now < until,
+    )
+
+
+def is_task_suspended(
+    task: Any,
+    *,
+    now: datetime | None = None,
+    tz_name: str | None = None,
+) -> bool:
+    return get_suspension_status(task, now=now, tz_name=tz_name).is_suspended
+
+
+def format_front_matter_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def update_markdown_front_matter_text(
+    text: str,
+    *,
+    updates: dict[str, Any] | None = None,
+    remove_keys: set[str] | None = None,
+) -> str:
+    updates = dict(updates or {})
+    remove_keys = set(remove_keys or set())
+
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("Markdown task file is missing front matter")
+
+    end_idx = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end_idx = idx
+            break
+    if end_idx is None:
+        raise ValueError("Markdown task file has unterminated front matter")
+
+    seen: set[str] = set()
+    new_front_lines: list[str] = []
+    default_newline = "\n"
+    for raw_line in lines[1:end_idx]:
+        if raw_line.endswith("\r\n"):
+            default_newline = "\r\n"
+        elif raw_line.endswith("\n"):
+            default_newline = "\n"
+        match = _FRONT_MATTER_LINE_RE.match(raw_line)
+        if not match:
+            new_front_lines.append(raw_line)
+            continue
+
+        indent, key, sep, _value, newline = match.groups()
+        if key in remove_keys:
+            seen.add(key)
+            continue
+        if key in updates:
+            seen.add(key)
+            line_end = newline or default_newline
+            new_front_lines.append(
+                f"{indent}{key}{sep}{format_front_matter_value(updates[key])}{line_end}"
+            )
+        else:
+            new_front_lines.append(raw_line)
+
+    missing_updates = [
+        key for key in updates if key not in seen and key not in remove_keys
+    ]
+    for key in missing_updates:
+        new_front_lines.append(
+            f"{key}: {format_front_matter_value(updates[key])}{default_newline}"
+        )
+
+    return "".join([lines[0], *new_front_lines, *lines[end_idx:]])
+
+
+def update_markdown_front_matter(
+    task_file: Path,
+    *,
+    updates: dict[str, Any] | None = None,
+    remove_keys: set[str] | None = None,
+) -> None:
+    content = task_file.read_text(encoding="utf-8")
+    new_content = update_markdown_front_matter_text(
+        content,
+        updates=updates,
+        remove_keys=remove_keys,
+    )
+    task_file.write_text(new_content, encoding="utf-8")
+
+
+def update_task_file_metadata(
+    task_file: Path,
+    *,
+    task_name: str,
+    updates: dict[str, Any] | None = None,
+    remove_keys: set[str] | None = None,
+) -> None:
+    if task_file.suffix.lower() == ".md":
+        update_markdown_front_matter(
+            task_file,
+            updates=updates,
+            remove_keys=remove_keys,
+        )
+        return
+    if task_file.suffix.lower() != ".toml":
+        raise ValueError(f"Unsupported task file format: {task_file}")
+
+    import tomlkit
+
+    doc = tomlkit.loads(task_file.read_text(encoding="utf-8"))
+    updates = dict(updates or {})
+    remove_keys = set(remove_keys or set())
+
+    target = None
+    task_section = doc.get("task")
+    if hasattr(task_section, "get") and task_section.get("name") == task_name:
+        target = task_section
+    else:
+        for key, value in doc.items():
+            if key.startswith("task") and hasattr(value, "get"):
+                if value.get("name") == task_name:
+                    target = value
+                    break
+
+    if target is None:
+        raise ValueError(f"Task '{task_name}' not found in {task_file}")
+
+    for key in remove_keys:
+        if key in target:
+            del target[key]
+    for key, value in updates.items():
+        target[key] = value
+
+    task_file.write_text(tomlkit.dumps(doc), encoding="utf-8")

--- a/src/kage/tui.py
+++ b/src/kage/tui.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import locale
 from datetime import datetime
 import os
-import re
 from typing import Any
 
 from textual.app import App, ComposeResult
@@ -76,6 +75,8 @@ def _format_task_details(task: dict[str, Any], *, is_ja: bool) -> str:
         f"{'タイムゾーン' if is_ja else 'Timezone'}: {task.get('task_timezone') or '-'}",
         f"{'許可時間' if is_ja else 'Allowed Hours'}: {_safe_str(task.get('allowed_hours'))}",
         f"{'禁止時間' if is_ja else 'Denied Hours'}: {_safe_str(task.get('denied_hours'))}",
+        f"{'停止' if is_ja else 'Suspension'}: {_safe_str(task.get('suspension_summary'))}",
+        f"{'停止理由' if is_ja else 'Suspend Reason'}: {_safe_str(task.get('suspended_reason'))}",
         f"{'タイムアウト' if is_ja else 'Timeout'}: {_safe_str(task.get('timeout_minutes'))}",
         f"{'Compiled' if not is_ja else 'Compiled'}: {_safe_str(task.get('compiled_state'))}",
     ]
@@ -319,14 +320,27 @@ class KageTuiApp(App[None]):
         task_file = Path(task["file"])
         if not task_file.exists():
             return
-        content = task_file.read_text(encoding="utf-8")
         current_active = task["active"]
-        new_val = "false" if current_active else "true"
-        if "active:" in content:
-            content = re.sub(r"active:\s*(true|false)", f"active: {new_val}", content)
+        if task_file.suffix.lower() == ".md":
+            from .suspension import update_markdown_front_matter
+
+            update_markdown_front_matter(
+                task_file,
+                updates={"active": not current_active},
+            )
         else:
-            content = re.sub(r"(cron:.*?\n)", rf"\1active: {new_val}\n", content)
-        task_file.write_text(content, encoding="utf-8")
+            import tomlkit
+
+            content = task_file.read_text(encoding="utf-8")
+            doc = tomlkit.loads(content)
+            if "task" in doc:
+                doc["task"]["active"] = not current_active
+            else:
+                for key, value in doc.items():
+                    if key.startswith("task") and hasattr(value, "get"):
+                        if value.get("name") == task["name"]:
+                            value["active"] = not current_active
+            task_file.write_text(tomlkit.dumps(doc), encoding="utf-8")
         self._reload()
 
     def _reload(self) -> None:
@@ -457,7 +471,10 @@ class KageTuiApp(App[None]):
         table = self.query_one("#tasks-table", DataTable)
         table.clear(columns=False)
         for task in self.tasks:
-            indicator = "●" if task["active"] else "─"
+            if task.get("is_suspended"):
+                indicator = "⏸"
+            else:
+                indicator = "●" if task["active"] else "─"
             table.add_row(indicator, _task_label(task), key=_task_key(task))
         self._move_cursor(
             table,

--- a/src/kage/web.py
+++ b/src/kage/web.py
@@ -1261,7 +1261,9 @@ INDEX_HTML = """
             
             filteredTasks.forEach(task => {
                 let nextRunDisplay = 'Not scheduled';
-                if (task.next_run && task.active) {
+                if (task.is_suspended) {
+                    nextRunDisplay = task.suspension_summary || 'Suspended';
+                } else if (task.next_run && task.active) {
                     try {
                         const d = new Date(task.next_run);
                         if (!isNaN(d.getTime())) {
@@ -1288,6 +1290,8 @@ INDEX_HTML = """
                     { key: 'Timeout', val: task.timeout_minutes ? task.timeout_minutes + ' min' : null },
                     { key: 'Allowed Hours', val: task.allowed_hours },
                     { key: 'Denied Hours', val: task.denied_hours },
+                    { key: 'Suspension', val: task.suspension_summary && task.suspension_summary !== '-' ? task.suspension_summary : null },
+                    { key: 'Suspend Reason', val: task.suspended_reason },
                     { key: 'Shell', val: task.shell },
                     { key: 'Command', val: task.command },
                     { key: 'Provider', val: task.provider_display }
@@ -1321,10 +1325,12 @@ INDEX_HTML = """
                 }
 
                 tasksHtml += `
-                    <div class="card ${task.active ? '' : 'inactive'}" style="margin-bottom: 16px;" id="task-${escapeHtml(task.name)}">
+                    <div class="card ${task.active && !task.is_suspended ? '' : 'inactive'}" style="margin-bottom: 16px;" id="task-${escapeHtml(task.name)}">
                         <div class="card-header">
                             <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
                                 <h4 style="margin:0; font-size: 1rem;">${escapeHtml(task.name)}</h4>
+                                ${task.suspension_invalid ? '<span class="status-badge" style="background:rgba(218,54,51,0.15); color:var(--error-text);">SUSPEND INVALID</span>' : ''}
+                                ${task.is_suspended && !task.suspension_invalid ? '<span class="status-badge" style="background:rgba(210,153,34,0.15); color:var(--warning);">SUSPENDED</span>' : ''}
                                 ${task.compiled_state === 'fresh' ? '<span class="status-badge" style="background:rgba(35,134,54,0.15); color:var(--success-text);">LOCK FRESH</span>' : ''}
                                 ${task.compiled_state === 'stale' ? '<span class="status-badge" style="background:rgba(218,54,51,0.15); color:var(--error-text);">LOCK STALE</span>' : ''}
                                 ${task.compiled_state === 'none' ? '<span class="status-badge" style="background:rgba(110,118,129,0.15); color:var(--text-dim);">NO LOCK</span>' : ''}
@@ -1351,7 +1357,7 @@ INDEX_HTML = """
                             <span class="details-icon">▼</span> Details
                         </button>
 
-                        <button class="btn" onclick="runTaskNow('${task.project_path}', '${task.name}', '${task.file}')" style="margin-top: 12px; width: 100%; font-size: 0.8rem;" ${task.active ? '' : 'disabled'}>Run Now</button>
+                        <button class="btn" onclick="runTaskNow('${task.project_path}', '${task.name}', '${task.file}')" style="margin-top: 12px; width: 100%; font-size: 0.8rem;" ${task.active && !task.is_suspended ? '' : 'disabled'}>Run Now</button>
                     </div>
                 `;
             });
@@ -1393,10 +1399,12 @@ INDEX_HTML = """
                         });
                         if (!response.ok) throw new Error('Failed to toggle task');
 
-                        if (active) card.classList.remove('inactive');
+                        const taskData = allConfigData.tasks.find(t => t.project_path === projectPath && t.name === taskName && (!file || t.file === file));
+                        const isSuspended = Boolean(taskData && taskData.is_suspended);
+                        if (active && !isSuspended) card.classList.remove('inactive');
                         else card.classList.add('inactive');
                         
-                        if (runBtn) runBtn.disabled = !active;
+                        if (runBtn) runBtn.disabled = !active || isSuspended;
 
                     } catch (error) {
                         alert(error.message);
@@ -1851,6 +1859,7 @@ def get_config_api():
     from .compiler import compiled_task_indicator
     from .scheduler import get_projects
     from .parser import load_project_tasks
+    from .suspension import get_suspension_status
     from datetime import datetime, timezone as dt_timezone
     import zoneinfo
     from croniter import croniter
@@ -1858,15 +1867,15 @@ def get_config_api():
     config = get_global_config()
     projects = get_projects()
 
-    # Setup timezone for calculating next run
-    tz_name = config.timezone
-    try:
-        tz = zoneinfo.ZoneInfo(tz_name)
-    except Exception:
-        tz = dt_timezone.utc
     all_tasks = []
     for proj_dir in projects:
         merged_cfg = get_global_config(workspace_dir=proj_dir)
+        # Setup timezone for calculating next run
+        tz_name = merged_cfg.timezone or config.timezone
+        try:
+            tz = zoneinfo.ZoneInfo(tz_name)
+        except Exception:
+            tz = dt_timezone.utc
         tasks = load_project_tasks(proj_dir)
         for toml_path, task_def in tasks:
             t = task_def.task
@@ -1892,6 +1901,7 @@ def get_config_api():
 
             # Use task-specific timezone if defined, otherwise fallback to global
             task_tz = tz
+            task_tz_name = t.timezone or tz_name
             if t.timezone:
                 try:
                     task_tz = zoneinfo.ZoneInfo(t.timezone)
@@ -1899,6 +1909,11 @@ def get_config_api():
                     pass
 
             task_now = datetime.now(task_tz)
+            suspension = get_suspension_status(
+                t,
+                now=task_now,
+                tz_name=task_tz_name,
+            )
             next_run_str = ""
             try:
                 itr = croniter(t.cron, task_now)
@@ -1922,6 +1937,11 @@ def get_config_api():
                     "timeout_minutes": t.timeout_minutes,
                     "allowed_hours": t.allowed_hours,
                     "denied_hours": t.denied_hours,
+                    "suspended_until": t.suspended_until,
+                    "suspended_reason": t.suspended_reason,
+                    "is_suspended": suspension.is_suspended,
+                    "suspension_invalid": suspension.is_invalid,
+                    "suspension_summary": suspension.summary,
                     "provider": t.provider
                     or (t.ai.engine if (t.ai and t.ai.engine) else None),
                     "provider_display": provider_display,
@@ -1950,7 +1970,8 @@ def run_task_now(req: RunTaskRequest):
     from pathlib import Path
     from fastapi.responses import JSONResponse
     from .parser import load_project_tasks
-    from .executor import execute_task
+    from .executor import TaskExecutionResult, execute_task
+    from .suspension import get_suspension_status
 
     proj_dir = Path(req.project_path).expanduser().resolve()
     if not proj_dir.exists():
@@ -1978,7 +1999,36 @@ def run_task_now(req: RunTaskRequest):
             )
 
         task_file, task = matched
-        execute_task(proj_dir, task, task_file=task_file)
+        cfg = get_global_config(workspace_dir=proj_dir)
+        suspension = get_suspension_status(
+            task,
+            tz_name=task.timezone or cfg.timezone,
+        )
+        if suspension.is_suspended:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "error": f"Task '{req.task_name}' is suspended: {suspension.summary}"
+                },
+            )
+        result = execute_task(proj_dir, task, task_file=task_file)
+        if result != TaskExecutionResult.STARTED:
+            status_code = (
+                409
+                if result
+                in {
+                    TaskExecutionResult.SKIPPED_INACTIVE,
+                    TaskExecutionResult.SKIPPED_CONCURRENCY,
+                    TaskExecutionResult.SKIPPED_SUSPENDED,
+                }
+                else 400
+            )
+            return JSONResponse(
+                status_code=status_code,
+                content={
+                    "error": f"Task '{req.task_name}' did not start: {result.value}"
+                },
+            )
         return {"message": f"Task '{req.task_name}' started."}
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
@@ -2000,8 +2050,8 @@ def stop_execution_api(exec_id: str):
 @app.post("/api/tasks/toggle")
 def toggle_task(req: ToggleTaskRequest):
     import tomlkit
-    import re
     from pathlib import Path
+    from .suspension import update_markdown_front_matter
 
     task_file = Path(req.file) if req.file else None
     if not task_file or not task_file.exists():
@@ -2010,25 +2060,21 @@ def toggle_task(req: ToggleTaskRequest):
     try:
         content = task_file.read_text(encoding="utf-8")
         if task_file.suffix == ".md":
-            new_val = "true" if req.active else "false"
-            if "active:" in content:
-                content = re.sub(
-                    r"active:\s*(true|false)", f"active: {new_val}", content
-                )
-            else:
-                content = re.sub(r"(cron:.*?\n)", rf"\1active: {new_val}\n", content)
+            update_markdown_front_matter(task_file, updates={"active": req.active})
+            content = None
         else:
-            doc = tomlkit.load(content)
+            doc = tomlkit.loads(content)
             if "task" in doc:
                 doc["task"]["active"] = req.active
             else:
                 for k, v in doc.items():
-                    if k.startswith("task") and isinstance(v, dict):
+                    if k.startswith("task") and hasattr(v, "get"):
                         if v.get("name") == req.task_name:
                             v["active"] = req.active
             content = tomlkit.dumps(doc)
 
-        task_file.write_text(content, encoding="utf-8")
+        if content is not None:
+            task_file.write_text(content, encoding="utf-8")
         return {
             "message": f"Task '{req.task_name}' {'enabled' if req.active else 'disabled'}."
         }

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -47,6 +47,7 @@ def test_generate_chat_reply(mock_run, mock_get_config):
     assert "gpt-5-codex" in mock_run.call_args[0][0]
     assert any("hi" in arg for arg in mock_run.call_args[0][0])
     assert any("You are Kage" in arg for arg in mock_run.call_args[0][0])
+    assert any("kage task suspend" in arg for arg in mock_run.call_args[0][0])
 
 
 @patch("kage.ai.chat.get_global_config")
@@ -187,6 +188,7 @@ def test_generate_logged_chat_reply_creates_run_and_metadata(
     metadata = load_run_metadata(result["run_id"])
     assert metadata["connector"]["name"] == "test_connector"
     assert "You are Kage" in metadata["prompt"]
+    assert "kage task suspend" in metadata["prompt"]
     assert "test_connector" in metadata["prompt"]
     assert "discord" in metadata["prompt"]
     assert "Format links, markdown" in metadata["prompt"]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -19,6 +19,7 @@ from kage.runs import load_run_metadata
 from kage.executor import (
     _build_connector_notification_message,
     _normalize_headless_args,
+    TaskExecutionResult,
     execute_task,
 )
 from kage.parser import TaskDef
@@ -128,6 +129,115 @@ def test_execute_shell_command_with_custom_shell(
     cmd = popen.call_args.args[0]
     assert Path(cmd[0]).name == "bash"
     assert cmd[1:] == ["-c", "echo hello"]
+
+
+def test_execute_task_skips_current_suspension(
+    tmp_path: Path, mock_executor_env, mocker
+):
+    popen = mocker.patch("kage.executor.subprocess.Popen")
+    task = TaskDef(
+        name="shell",
+        cron="* * * * *",
+        command="echo hello",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
+
+    started = execute_task(tmp_path, task)
+
+    assert started == TaskExecutionResult.SKIPPED_SUSPENDED
+    popen.assert_not_called()
+
+
+def test_execute_task_skips_invalid_suspension(
+    tmp_path: Path, mock_executor_env, mocker
+):
+    popen = mocker.patch("kage.executor.subprocess.Popen")
+    task = TaskDef(
+        name="shell",
+        cron="* * * * *",
+        command="echo hello",
+        suspended_until="not-a-date",
+    )
+
+    started = execute_task(tmp_path, task)
+
+    assert started == TaskExecutionResult.SKIPPED_SUSPENDED
+    popen.assert_not_called()
+
+
+def test_execute_task_allows_expired_suspension(
+    tmp_path: Path, mock_executor_env, mocker
+):
+    popen = mocker.patch("kage.executor.subprocess.Popen", return_value=DummyProc())
+    task = TaskDef(
+        name="shell",
+        cron="* * * * *",
+        command="echo hello",
+        suspended_until="2000-01-01T00:00:00+00:00",
+    )
+
+    started = execute_task(tmp_path, task)
+
+    assert started == TaskExecutionResult.STARTED
+    popen.assert_called_once()
+
+
+def test_execute_task_force_bypasses_current_suspension(
+    tmp_path: Path, mock_executor_env, mocker
+):
+    popen = mocker.patch("kage.executor.subprocess.Popen", return_value=DummyProc())
+    task = TaskDef(
+        name="shell",
+        cron="* * * * *",
+        command="echo hello",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
+
+    started = execute_task(tmp_path, task, force=True)
+
+    assert started == TaskExecutionResult.STARTED
+    popen.assert_called_once()
+
+
+def test_execute_task_returns_failed_config_when_command_spawn_fails(
+    tmp_path: Path, mock_executor_env, mocker
+):
+    update_execution = mocker.patch("kage.executor.update_execution")
+    start_execution = mocker.patch(
+        "kage.executor.start_execution", return_value="exec-spawn-fail"
+    )
+    mocker.patch(
+        "kage.executor.run_logged_command", side_effect=FileNotFoundError("missing cli")
+    )
+
+    task = TaskDef(name="shell", cron="* * * * *", command="echo hello")
+
+    result = execute_task(tmp_path, task)
+
+    assert result == TaskExecutionResult.FAILED_CONFIG
+    assert start_execution.called
+    assert update_execution.call_args.args[1] == "ERROR"
+    assert "missing cli" in update_execution.call_args.args[3]
+
+
+def test_execute_task_returns_started_when_command_setup_fails_after_spawn(
+    tmp_path: Path, mock_executor_env, mocker
+):
+    update_execution = mocker.patch("kage.executor.update_execution")
+    popen = mocker.patch("kage.executor.subprocess.Popen", return_value=DummyProc())
+    mocker.patch(
+        "kage.executor._stream_process_output",
+        side_effect=RuntimeError("stream wiring failed"),
+    )
+
+    task = TaskDef(name="shell", cron="* * * * *", command="echo hello")
+
+    result = execute_task(tmp_path, task)
+
+    assert result == TaskExecutionResult.STARTED
+    popen.assert_called_once()
+    assert update_execution.call_args.args[1] == "ERROR"
+    assert "stream wiring failed" in update_execution.call_args.args[3]
 
 
 def test_execute_task_injects_artifact_dir_for_connector_notifications(
@@ -362,9 +472,10 @@ Fix this
     )
 
     task = TaskDef(name="ai_task", cron="* * * * *", prompt="Fix this")
-    execute_task(tmp_path, task, task_file=task_file)
+    result = execute_task(tmp_path, task, task_file=task_file)
 
     popen.assert_not_called()
+    assert result == TaskExecutionResult.FAILED_CONFIG
     assert start_execution.call_args.kwargs["execution_kind"] == "compiled"
     assert "Compiled lock is stale" in update_execution.call_args.args[3]
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -57,6 +57,29 @@ Include benchmark table and recommendations.
     assert task.working_dir == "../../workspace"
 
 
+def test_parse_markdown_front_matter_suspension_fields(tmp_path: Path):
+    task_file = tmp_path / "suspended.md"
+    task_file.write_text(
+        """---
+name: Suspended Task
+cron: "0 2 * * *"
+suspended_until: "2026-05-09T18:30:00+09:00"
+suspended_reason: "Vacation for 2 weeks"
+---
+
+Do this later.
+""",
+        encoding="utf-8",
+    )
+
+    parsed = parse_task_file(task_file)
+
+    assert len(parsed) == 1
+    _, task = parsed[0]
+    assert task.suspended_until == "2026-05-09T18:30:00+09:00"
+    assert task.suspended_reason == "Vacation for 2 weeks"
+
+
 def test_parse_markdown_command_task(tmp_path: Path):
     task_file = tmp_path / "shell.md"
     task_file.write_text(

--- a/tests/test_runs_cli.py
+++ b/tests/test_runs_cli.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import tomlkit
 from typer.testing import CliRunner
 
 from kage import db
 from kage.compiler import get_task_source_fingerprints
 from kage.config import CommandDef, GlobalConfig, ProviderConfig
+from kage.executor import TaskExecutionResult
 from kage.main import app
 from kage.parser import TaskDef
 from kage.runs import format_local_timestamp, format_relative_timestamp, get_run
@@ -272,7 +274,12 @@ def test_task_list_shows_compiled_statuses(mocker, tmp_path: Path):
     shell_file = project_dir / ".kage" / "tasks" / "shell.md"
     task_file.parent.mkdir(parents=True)
 
-    prompt_task = TaskDef(name="Nightly", cron="* * * * *", prompt="hello")
+    prompt_task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        prompt="hello",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
     shell_task = TaskDef(name="Shell", cron="* * * * *", command="echo hi")
     cfg = GlobalConfig(
         default_ai_engine="gemini",
@@ -300,15 +307,314 @@ def test_task_list_shows_compiled_statuses(mocker, tmp_path: Path):
         ],
     )
 
-    result = runner.invoke(app, ["task", "list"], env={"COLUMNS": "160"})
+    result = runner.invoke(app, ["task", "list"], env={"COLUMNS": "220"})
 
     assert result.exit_code == 0
     assert "Nightly" in result.stdout
     assert "Shell" in result.stdout
     assert "Prompt (Compiled)" in result.stdout
     assert "gemini (Inherited)" in result.stdout
+    assert "2999-01-01T00:00:00+00:00" in result.stdout
     assert "proj" in result.stdout
     assert str(project_dir) not in result.stdout
+
+
+def test_task_suspend_until_updates_frontmatter_without_body(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task_file.parent.mkdir(parents=True)
+    task_file.write_text(
+        """---
+name: Nightly
+cron: "* * * * *"
+---
+
+# Prompt
+
+Keep this body exactly.
+""",
+        encoding="utf-8",
+    )
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+    mocker.patch(
+        "kage.config.get_global_config",
+        side_effect=lambda workspace_dir=None: GlobalConfig(timezone="UTC"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "suspend",
+            "Nightly",
+            "--until",
+            "2026-05-09",
+            "--reason",
+            "Vacation",
+        ],
+    )
+
+    assert result.exit_code == 0
+    content = task_file.read_text(encoding="utf-8")
+    assert 'suspended_until: "2026-05-09T00:00:00+00:00"' in content
+    assert 'suspended_reason: "Vacation"' in content
+    assert content.split("---\n", 2)[2] == "\n# Prompt\n\nKeep this body exactly.\n"
+
+
+def test_task_resume_removes_suspension_fields(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task_file.parent.mkdir(parents=True)
+    task_file.write_text(
+        """---
+name: Nightly
+cron: "* * * * *"
+suspended_until: "2026-05-09T00:00:00+00:00"
+suspended_reason: "Vacation"
+---
+
+hello
+""",
+        encoding="utf-8",
+    )
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+
+    result = runner.invoke(app, ["task", "resume", "Nightly"])
+
+    assert result.exit_code == 0
+    content = task_file.read_text(encoding="utf-8")
+    assert "suspended_until" not in content
+    assert "suspended_reason" not in content
+    assert content.endswith("\nhello\n")
+
+
+def test_task_suspend_updates_toml_task_section(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.toml"
+    task_file.parent.mkdir(parents=True)
+    task_file.write_text(
+        """
+[task_nightly]
+name = "Nightly"
+cron = "* * * * *"
+command = "echo hello"
+
+[task_other]
+name = "Other"
+cron = "* * * * *"
+command = "echo other"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+    mocker.patch(
+        "kage.config.get_global_config",
+        side_effect=lambda workspace_dir=None: GlobalConfig(timezone="UTC"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "task",
+            "suspend",
+            "Nightly",
+            "--until",
+            "2026-05-09",
+            "--reason",
+            "Vacation",
+        ],
+    )
+
+    assert result.exit_code == 0
+    doc = tomlkit.parse(task_file.read_text(encoding="utf-8"))
+    assert doc["task_nightly"]["suspended_until"] == "2026-05-09T00:00:00+00:00"
+    assert doc["task_nightly"]["suspended_reason"] == "Vacation"
+    assert "suspended_until" not in doc["task_other"]
+
+
+def test_task_resume_removes_suspension_fields_from_toml_task(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.toml"
+    task_file.parent.mkdir(parents=True)
+    task_file.write_text(
+        """
+[task_nightly]
+name = "Nightly"
+cron = "* * * * *"
+command = "echo hello"
+suspended_until = "2026-05-09T00:00:00+00:00"
+suspended_reason = "Vacation"
+
+[task_other]
+name = "Other"
+cron = "* * * * *"
+command = "echo other"
+suspended_until = "2026-05-01T00:00:00+00:00"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+
+    result = runner.invoke(app, ["task", "resume", "Nightly"])
+
+    assert result.exit_code == 0
+    doc = tomlkit.parse(task_file.read_text(encoding="utf-8"))
+    assert "suspended_until" not in doc["task_nightly"]
+    assert "suspended_reason" not in doc["task_nightly"]
+    assert doc["task_other"]["suspended_until"] == "2026-05-01T00:00:00+00:00"
+
+
+def test_task_suspend_without_reason_preserves_existing_reason(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task_file.parent.mkdir(parents=True)
+    task_file.write_text(
+        """---
+name: Nightly
+cron: "* * * * *"
+suspended_until: "2026-05-01T00:00:00+00:00"
+suspended_reason: "Keep this note"
+---
+
+hello
+""",
+        encoding="utf-8",
+    )
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+    mocker.patch(
+        "kage.config.get_global_config",
+        side_effect=lambda workspace_dir=None: GlobalConfig(timezone="UTC"),
+    )
+
+    result = runner.invoke(
+        app,
+        ["task", "suspend", "Nightly", "--until", "2026-05-09"],
+    )
+
+    assert result.exit_code == 0
+    content = task_file.read_text(encoding="utf-8")
+    assert 'suspended_until: "2026-05-09T00:00:00+00:00"' in content
+    assert 'suspended_reason: "Keep this note"' in content
+
+
+def test_task_suspend_requires_project_when_ambiguous(mocker, tmp_path: Path):
+    project_a = tmp_path / "a"
+    project_b = tmp_path / "b"
+    for project_dir in (project_a, project_b):
+        task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+        task_file.parent.mkdir(parents=True)
+        task_file.write_text(
+            """---
+name: Nightly
+cron: "* * * * *"
+---
+
+hello
+""",
+            encoding="utf-8",
+        )
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_a, project_b])
+
+    result = runner.invoke(
+        app,
+        ["task", "suspend", "Nightly", "--until", "2026-05-09"],
+    )
+
+    assert result.exit_code == 1
+    assert "exists in multiple projects" in result.stdout
+
+
+def test_task_run_force_passes_force_to_executor(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        command="echo hi",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
+    mocker.patch(
+        "kage.main._resolve_named_task",
+        return_value=(project_dir, task_file, task),
+    )
+    execute_task = mocker.patch(
+        "kage.executor.execute_task", return_value=TaskExecutionResult.STARTED
+    )
+
+    result = runner.invoke(app, ["task", "run", "Nightly", "--force"])
+
+    assert result.exit_code == 0
+    assert execute_task.call_args.kwargs["force"] is True
+
+
+def test_task_run_without_force_blocks_suspended_task(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        command="echo hi",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
+    mocker.patch(
+        "kage.main._resolve_named_task",
+        return_value=(project_dir, task_file, task),
+    )
+    mocker.patch(
+        "kage.config.get_global_config",
+        side_effect=lambda workspace_dir=None: GlobalConfig(timezone="UTC"),
+    )
+    execute_task = mocker.patch(
+        "kage.executor.execute_task", return_value=TaskExecutionResult.STARTED
+    )
+
+    result = runner.invoke(app, ["task", "run", "Nightly"])
+
+    assert result.exit_code == 1
+    assert "is suspended" in result.stdout
+    execute_task.assert_not_called()
+
+
+def test_top_level_run_force_passes_force_to_executor(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        command="echo hi",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
+    mocker.patch(
+        "kage.main._resolve_named_task",
+        return_value=(project_dir, task_file, task),
+    )
+    execute_task = mocker.patch(
+        "kage.executor.execute_task", return_value=TaskExecutionResult.STARTED
+    )
+
+    result = runner.invoke(app, ["run", "Nightly", "--force"])
+
+    assert result.exit_code == 0
+    assert execute_task.call_args.kwargs["force"] is True
+
+
+def test_task_run_reports_non_started_executor_result(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task = TaskDef(name="Nightly", cron="* * * * *", command="echo hi")
+    mocker.patch(
+        "kage.main._resolve_named_task",
+        return_value=(project_dir, task_file, task),
+    )
+    mocker.patch(
+        "kage.executor.execute_task", return_value=TaskExecutionResult.FAILED_CONFIG
+    )
+
+    result = runner.invoke(app, ["task", "run", "Nightly"])
+
+    assert result.exit_code == 1
+    assert "did not start" in result.stdout
+    assert "configuration is incomplete" in result.stdout
 
 
 def test_doctor_reports_stale_compiled_locks(mocker, tmp_path: Path):
@@ -393,7 +699,13 @@ Create a report
 """,
         encoding="utf-8",
     )
-    task = TaskDef(name="Nightly", cron="* * * * *", prompt="Create a report")
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        prompt="Create a report",
+        suspended_until="2999-01-01T00:00:00+00:00",
+        suspended_reason="Vacation",
+    )
     prompt_hash = get_task_source_fingerprints(task_file)["prompt_hash"]
     cfg = GlobalConfig(
         default_ai_engine="gemini",
@@ -415,3 +727,5 @@ Create a report
     assert result.exit_code == 0
     assert "Prompt Hash" in result.stdout
     assert prompt_hash in result.stdout
+    assert "Suspension" in result.stdout
+    assert "Vacation" in result.stdout

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+from types import SimpleNamespace
+from datetime import datetime, timezone as dt_timezone
+
+from kage.parser import TaskDef
+from kage.scheduler import run_all_scheduled_tasks
+
+
+def test_scheduler_skips_current_and_invalid_suspensions(mocker, tmp_path: Path):
+    project_dir = tmp_path / "proj"
+    future_file = project_dir / ".kage" / "tasks" / "future.md"
+    invalid_file = project_dir / ".kage" / "tasks" / "invalid.md"
+    expired_file = project_dir / ".kage" / "tasks" / "expired.md"
+
+    future_task = TaskDef(
+        name="Future",
+        cron="* * * * *",
+        command="echo future",
+        suspended_until="2999-01-01T00:00:00+00:00",
+    )
+    invalid_task = TaskDef(
+        name="Invalid",
+        cron="* * * * *",
+        command="echo invalid",
+        suspended_until="not-a-date",
+    )
+    expired_task = TaskDef(
+        name="Expired",
+        cron="* * * * *",
+        command="echo expired",
+        suspended_until="2000-01-01T00:00:00+00:00",
+    )
+
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+    mocker.patch(
+        "kage.scheduler.get_global_config",
+        return_value=SimpleNamespace(timezone="UTC"),
+    )
+    mocker.patch(
+        "kage.scheduler.load_project_tasks",
+        return_value=[
+            (future_file, SimpleNamespace(task=future_task)),
+            (invalid_file, SimpleNamespace(task=invalid_task)),
+            (expired_file, SimpleNamespace(task=expired_task)),
+        ],
+    )
+    execute_task = mocker.patch("kage.scheduler.execute_task")
+    mocker.patch("kage.connectors.runner.run_connectors")
+
+    run_all_scheduled_tasks()
+
+    execute_task.assert_called_once_with(
+        project_dir,
+        expired_task,
+        task_file=expired_file,
+    )
+
+
+def test_scheduler_uses_project_timezone_for_date_only_suspension(
+    mocker, tmp_path: Path
+):
+    project_dir = tmp_path / "proj"
+    task_file = project_dir / ".kage" / "tasks" / "nightly.md"
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        command="echo hi",
+        suspended_until="2026-05-09",
+    )
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            current = datetime(2026, 5, 8, 16, 0, 30, tzinfo=dt_timezone.utc)
+            return current if tz is None else current.astimezone(tz)
+
+    mocker.patch("kage.scheduler.datetime", FrozenDateTime)
+    mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
+    mocker.patch(
+        "kage.scheduler.get_global_config",
+        side_effect=lambda workspace_dir=None: SimpleNamespace(
+            timezone="Asia/Tokyo" if workspace_dir else "UTC"
+        ),
+    )
+    mocker.patch(
+        "kage.scheduler.load_project_tasks",
+        return_value=[(task_file, SimpleNamespace(task=task))],
+    )
+    execute_task = mocker.patch("kage.scheduler.execute_task")
+    mocker.patch("kage.connectors.runner.run_connectors")
+
+    run_all_scheduled_tasks()
+
+    execute_task.assert_called_once_with(project_dir, task, task_file=task_file)

--- a/tests/test_suspension.py
+++ b/tests/test_suspension.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from kage.parser import TaskDef
+from kage.suspension import (
+    get_suspension_status,
+    parse_suspension_deadline,
+    parse_suspension_duration,
+    suspension_deadline_from_duration,
+    update_markdown_front_matter_text,
+)
+
+
+def test_parse_suspension_deadline_date_uses_task_timezone_midnight():
+    deadline = parse_suspension_deadline("2026-05-09", tz_name="Asia/Tokyo")
+
+    assert deadline.isoformat(timespec="seconds") == "2026-05-09T00:00:00+09:00"
+
+
+def test_parse_suspension_duration_accepts_single_token_units():
+    assert parse_suspension_duration("30m").total_seconds() == 30 * 60
+    assert parse_suspension_duration("3h").total_seconds() == 3 * 60 * 60
+    assert parse_suspension_duration("14d").days == 14
+    assert parse_suspension_duration("2w").days == 14
+
+
+def test_parse_suspension_duration_rejects_invalid_tokens():
+    with pytest.raises(ValueError):
+        parse_suspension_duration("1d 2h")
+
+    with pytest.raises(ValueError):
+        parse_suspension_duration("0d")
+
+
+def test_suspension_deadline_from_duration_uses_task_timezone():
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+
+    deadline = suspension_deadline_from_duration(
+        "2w",
+        now=now,
+        tz_name="Asia/Tokyo",
+    )
+
+    assert deadline.isoformat(timespec="seconds") == "2026-05-09T12:00:00+09:00"
+
+
+def test_suspension_deadline_from_duration_uses_elapsed_time_across_dst():
+    now = datetime(2026, 3, 7, 12, 0, tzinfo=ZoneInfo("America/New_York"))
+
+    deadline = suspension_deadline_from_duration(
+        "1d",
+        now=now,
+        tz_name="America/New_York",
+    )
+
+    assert deadline.isoformat(timespec="seconds") == "2026-03-08T13:00:00-04:00"
+    elapsed = deadline.astimezone(ZoneInfo("UTC")) - now.astimezone(ZoneInfo("UTC"))
+    assert elapsed.total_seconds() == 24 * 60 * 60
+
+
+def test_get_suspension_status_fails_closed_for_invalid_deadline():
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        prompt="hello",
+        suspended_until="not-a-date",
+    )
+
+    status = get_suspension_status(task, tz_name="UTC")
+
+    assert status.is_suspended is True
+    assert status.is_invalid is True
+
+
+def test_get_suspension_status_fails_closed_for_blank_deadline():
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        prompt="hello",
+        suspended_until="",
+    )
+
+    status = get_suspension_status(task, tz_name="UTC")
+
+    assert status.is_suspended is True
+    assert status.is_invalid is True
+
+
+def test_update_markdown_front_matter_preserves_prompt_body():
+    source = """---
+name: Nightly
+cron: "* * * * *"
+---
+
+# Prompt
+
+Keep this body exactly.
+"""
+
+    updated = update_markdown_front_matter_text(
+        source,
+        updates={
+            "suspended_until": "2026-05-09T00:00:00+09:00",
+            "suspended_reason": "Vacation",
+        },
+    )
+
+    assert 'suspended_until: "2026-05-09T00:00:00+09:00"' in updated
+    assert 'suspended_reason: "Vacation"' in updated
+    assert updated.split("---\n", 2)[2] == source.split("---\n", 2)[2]
+
+
+def test_update_markdown_front_matter_removes_suspension_keys():
+    source = """---
+name: Nightly
+cron: "* * * * *"
+suspended_until: "2026-05-09T00:00:00+09:00"
+suspended_reason: "Vacation"
+---
+
+hello
+"""
+
+    updated = update_markdown_front_matter_text(
+        source,
+        remove_keys={"suspended_until", "suspended_reason"},
+    )
+
+    assert "suspended_until" not in updated
+    assert "suspended_reason" not in updated
+    assert updated.endswith("\nhello\n")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -42,6 +42,8 @@ def test_format_task_details_includes_prompt_and_compiled_state():
             "timeout_minutes": 15,
             "compiled_state": "fresh",
             "compiled_path": "/tmp/demo/.kage/tasks/nightly.lock.sh",
+            "suspension_summary": "until: 2999-01-01T00:00:00+00:00",
+            "suspended_reason": "Vacation",
             "command": None,
             "prompt": "write a summary",
         },
@@ -51,6 +53,8 @@ def test_format_task_details_includes_prompt_and_compiled_state():
     assert "Prompt (Compiled)" in rendered
     assert "gemini (Inherited)" in rendered
     assert "Compiled Path" in rendered
+    assert "until: 2999-01-01T00:00:00+00:00" in rendered
+    assert "Vacation" in rendered
     assert "write a summary" in rendered
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -11,16 +11,31 @@ def test_get_config_api_includes_compiled_state(mocker, tmp_path: Path):
     task_file = project_dir / ".kage" / "tasks" / "nightly.md"
     task_file.parent.mkdir(parents=True)
 
-    cfg = GlobalConfig(
+    global_cfg = GlobalConfig(
+        timezone="UTC",
         default_ai_engine="codex",
         commands={"codex": CommandDef(template=["codex", "exec", "{prompt}"])},
         providers={"codex": ProviderConfig(command="codex")},
     )
-    task = TaskDef(name="Nightly", cron="* * * * *", prompt="hello")
+    workspace_cfg = GlobalConfig(
+        timezone="Asia/Tokyo",
+        default_ai_engine="codex",
+        commands={"codex": CommandDef(template=["codex", "exec", "{prompt}"])},
+        providers={"codex": ProviderConfig(command="codex")},
+    )
+    task = TaskDef(
+        name="Nightly",
+        cron="* * * * *",
+        prompt="hello",
+        suspended_until="2999-01-01",
+        suspended_reason="Vacation",
+    )
 
     mocker.patch(
         "kage.web.get_global_config",
-        side_effect=lambda workspace_dir=None: cfg,
+        side_effect=lambda workspace_dir=None: (
+            workspace_cfg if workspace_dir else global_cfg
+        ),
     )
     mocker.patch("kage.scheduler.get_projects", return_value=[project_dir])
     mocker.patch(
@@ -47,6 +62,11 @@ def test_get_config_api_includes_compiled_state(mocker, tmp_path: Path):
     assert payload["tasks"][0]["provider_display"] == "codex (Inherited)"
     assert payload["tasks"][0]["type_display"] == "Prompt (Compiled)"
     assert payload["tasks"][0]["project_name"] == "proj"
+    assert payload["tasks"][0]["is_suspended"] is True
+    assert payload["tasks"][0]["suspended_reason"] == "Vacation"
+    assert payload["tasks"][0]["suspension_summary"].startswith("until:")
+    assert payload["tasks"][0]["suspension_summary"].endswith("+09:00")
+    assert payload["tasks"][0]["task_timezone"] == "Asia/Tokyo"
 
 
 def test_connector_setup_guides_escape_backticks_in_embedded_js():


### PR DESCRIPTION
## Summary
- add deadline-based task suspension fields and helpers
- add suspend/resume CLI plus force support for manual runs
- surface suspension state across doctor, CLI, web, TUI, docs, and connector guidance

## Verification
- uvx ruff format . && uvx ruff check . --fix
- .venv/bin/pytest

Release label: release:minor