### PR TITLE
feat(quest): event-driven quest lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ Cleanup old logs every midnight.
 
 | Command | Description |
 |---------|-------------|
+| `kage quest new <name> --direction "..."` | Create an event-driven quest: a team of role agents (scout → poc → strategist) explores a vague direction as a mind-map graph, one node per cron tick, with a `--max-agent-runs` runaway budget |
+| `kage quest list` | List quests and their node/run progress |
+| `kage quest show <id>` | Show a quest, its nodes, and edges |
+| `kage quest stop <id>` / `kage quest resume <id>` | Pause/resume a quest |
+| `kage quest abort-node <node_id>` | Force-abort a single quest node |
 | `kage onboard` | Global setup (cron, directories, DB) |
 | `kage init` | Initialize kage in the current directory |
 | `kage run <task>` | Run a specific task immediately; add `--force` to bypass suspension |

--- a/README_JA.md
+++ b/README_JA.md
@@ -251,6 +251,11 @@ shell: "bash"
 
 | コマンド | 説明 |
 |---------|-------------|
+| `kage quest new <name> --direction "..."` | event駆動のquestを作成。ロールエージェント(scout→poc→strategist)がマインドマップ状のグラフを形成し、cron tickごとに1ノードをディスパッチ。`--max-agent-runs` で暴走防止予算を設定 |
+| `kage quest list` | quest一覧とノード/実行回数の進捗 |
+| `kage quest show <id>` | questのノード・エッジを表示 |
+| `kage quest stop <id>` / `kage quest resume <id>` | questの一時停止/再開 |
+| `kage quest abort-node <node_id>` | 単一ノードを強制abort |
 | `kage onboard` | グローバルセットアップ |
 | `kage init` | 現在のディレクトリに kage を初期化 |
 | `kage run <task>` | 特定 task を即時実行。停止中 task は `--force` で実行 |

--- a/docs/quest/2026-06-24-quest-lifecycle/intent.md
+++ b/docs/quest/2026-06-24-quest-lifecycle/intent.md
@@ -1,0 +1,536 @@
+# Quest Lifecycle — Design & Intent
+
+Date: 2026-06-24
+Status: Proposal / Prototype skeleton
+
+## Goals
+
+- Introduce a second lifecycle alongside `cron`, called **quest**, that lets a team of AI agents explore a vague direction autonomously for long stretches (target: 24h continuous).
+- Model work as a **mind-map / task graph** (nodes + edges) instead of a linear checklist, so agents can branch, abort dead PoCs, and grow promising ones.
+- Drive everything from the existing 1-minute `kage cron run` tick (no new daemon), to keep kage's stateless, OS-native philosophy.
+- Provide runaway protection with a **max agent execution count** budget (other guards are future work).
+
+## Non-Goals (this iteration)
+
+- Wall-clock / token-cost budgets (designed for, not implemented).
+- Human approval gates via connectors.
+- Real LLM-decided graph expansion beyond a fixed role pipeline + simple verdict parsing.
+- Web/TUI visualization beyond tabular CLI output.
+
+## Lifecycle model
+
+### Coexistence with cron
+
+- A quest is created via `kage quest new` and stored in SQLite (`quests`, `quest_nodes`, `quest_edges` tables). It is **not** a `.kage/tasks/*.md` file.
+- On every `kage cron run` tick, after scheduled cron tasks and connectors, the scheduler calls `quest.tick()` once. The tick dispatches at most one pending node per active quest (synchronously), reusing the existing executor so runs/logs/metadata remain uniform.
+- Quests have no `cron` expression; activation is `status = active`. `kage quest stop` sets `status = stopped`; `kage quest resume` reactivates.
+
+### Roles & team
+
+Three role templates, each a provider + prompt skeleton that the runner materializes at dispatch time:
+
+- **scout** — investigates current state of the repo/world for a hypothesis and emits new candidate hypotheses.
+- **poc** — runs a minimal proof-of-concept for one hypothesis and emits a verdict (`promising` | `dead`) plus new directions.
+- **strategist** — evaluates accumulated evidence, decides grow/abort, and may close the quest.
+
+A quest declares which roles to enable and initial fans-out (e.g. N parallel scouts). The skeleton ships a fixed default team: `scout → poc → poc ... → strategist`.
+
+### Task graph
+
+- Each node: `role`, `hypothesis`, `status` (`pending` | `running` | `explored` | `aborted` | `growing`), `verdict`, `evidence`, `run_id`.
+- Edges record `spawned` / `aborted_to` / `grew_to` relations with timestamps.
+- Persistent in SQLite for queryability; CLI and (future) UI render the graph.
+
+### Run loop (per tick, per active quest)
+
+1. If `agent_runs >= max_agent_runs`, set `status = terminated` and skip.
+2. Select the oldest `pending` node whose parent (if any) is not `running`.
+3. Mark it `running`, build a role-specific prompt that includes the quest direction, ancestor evidence, and instructions to end with a fenced JSON block:
+   ```json
+   { "verdict": "promising" | "dead", "evidence": "...", "new_directions": ["..."] }
+   ```
+4. Synthesize an in-memory `TaskDef` (`mode: continuous`, no `task_file`) and call `executor.execute_task`. The run flows through normal logging/run history.
+5. Parse the JSON block from stdout:
+   - `promising` → mark node `explored`/`growing`, spawn child `poc` nodes for each `new_direction`.
+   - `dead` → mark `aborted`, spawn a `strategist` node (debounced: at most one pending strategist per quest).
+   - `strategist` run → may set quest `status = done`.
+6. Increment `agent_runs`. Persist node/edge/quest updates.
+
+### Termination conditions
+
+Implemented now:
+
+- **max_agent_runs** per quest (default 50). Hard stop → `terminated`.
+
+Reserved in schema for future:
+
+- `max_wall_minutes`, `max_token_budget` (columns present, not enforced yet).
+
+Manual:
+
+- `kage quest stop <id>` → `status = stopped` (ticks skip it).
+- `kage quest abort-node <node_id>` → force node `aborted`.
+
+## Schema (SQLite, added in `init_db`)
+
+```sql
+CREATE TABLE IF NOT EXISTS quests (
+  id TEXT PRIMARY KEY,
+  project_path TEXT NOT NULL,
+  name TEXT NOT NULL,
+  direction TEXT NOT NULL,
+  status TEXT NOT NULL,            -- active | done | terminated | stopped
+  max_agent_runs INTEGER NOT NULL DEFAULT 50,
+  agent_runs INTEGER NOT NULL DEFAULT 0,
+  roles_json TEXT,                 -- list of role names
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS quest_nodes (
+  id TEXT PRIMARY KEY,
+  quest_id TEXT NOT NULL,
+  parent_id TEXT,
+  role TEXT NOT NULL,
+  hypothesis TEXT NOT NULL,
+  status TEXT NOT NULL,            -- pending | running | explored | aborted | growing
+  verdict TEXT,
+  evidence TEXT,
+  run_id TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS quest_edges (
+  id TEXT PRIMARY KEY,
+  quest_id TEXT NOT NULL,
+  from_node TEXT,
+  to_node TEXT,
+  relation TEXT NOT NULL,          -- spawned | aborted_to | grew_to
+  created_at TEXT NOT NULL
+);
+```
+
+## CLI
+
+```
+kage quest new <name> --direction "..." [--project <path>]
+                     [--max-agent-runs 50] [--roles scout,poc,strategist]
+                     [--provider claude]
+kage quest list
+kage quest show <id>
+kage quest stop <id>
+kage quest resume <id>
+kage quest abort-node <node_id>
+```
+
+`kage quest list` prints id, name, status, agent_runs/max, node counts. `kage quest show` prints the quest plus its node table and edges.
+
+## Future work
+
+- Wall-clock / token budgets and cost tracking.
+- Connector approval gates at depth thresholds.
+- Persisted role prompt overrides per quest.
+
+## v2 — Owner-gated team model (2026-06-24)
+
+### Motivation
+
+現状スケルトンでは scout/poc が verdict を返すと Python の固定ルールで勝手に子ノードを spawn していた。これは「1 エージェントが独断で進める」構造で、LLM 1 個のミスが直接グラフに漏れる。1エージェントはまだミスが多いため、チームの総合力で戦いたい。
+
+### New rule: owner-only graph mutation
+
+- ロール `owner` を必ず 1 つ持つ。owner だけが **グラフの編集権** (新規ノード作成・状態更新・abort) を持つ。
+- それ以外のロール (scout/poc/strategist) は `execute` と `report` だけ。verdict / new_directions は **「提案 (proposed node)」** として蓄えられ、即 spawn はされない。
+- proposed ノードは `_select_pending_node` の候補から外れ、owner が `promote` action を出すまで実行されない。
+- owner ノードは proposed が一定数溜まる OR 直近の子が abort 済 OR 待機中のノードが枯渇したときにだけ dispatch される (`_should_dispatch_owner`)。
+- dispatch された owner は全子孫の evidence + proposed 一覧を受け取り、以下の actions を発する:
+  ```json
+  {
+    "actions": [
+      {"type":"promote", "node_id":"prop-001"},
+      {"type":"abort",   "node_id":"nb-123"},
+      {"type":"spawn",   "role":"poc", "direction":"..."},
+      {"type":"finish",  "reason":"..."}
+    ],
+    "evidence": "..."
+  }
+  ```
+- owner の verdict はグラフを直接変更せず、上記 action 列を `tick()` が検証付きで適用する。owner が未知の node_id や他人のノードを勝手に触ろうとしても `PermissionError` 相当で弾く。
+
+### Provenance
+
+proposed ノードには spawn 元 (`proposed_by` 列) と `relation=proposed_from` の edge を刻む。owner が誰の提案を触ったか追えるようにする。
+
+### Web UI (kage ui)
+
+追加 route:
+- `GET /quests` — クエスト一覧 + 個別グラフ描画 SPA ページ
+- `GET /api/quests` — 全クエスト + runs/max/roles JSON
+- `GET /api/quests/{id}` — そのクエストの nodes + edges JSON
+
+ページではノードを SVG で layered tree 描画。色 = 状態 (proposed は点線・pending 実線・aborted 赤・growing 緑)、owner ノードは王冠アイコンで区別。エッジは relation で々 (promote/grew_to/aborted_to/proposed_from)。
+
+sample directory:
+- `/quests` を `/runs` と同居させるのではなく独立 SPA 1ページにし、既存ダッシュボードのサイドバーから遷移。
+
+### Non-goals (v2)
+
+- owner の LLM 出力の actions を“完全 validation” するのはスコープ外。未知 ID / 不正 role くらいは弾くが、破壊的 action は基本信頼。
+- 提案の自動間引き依然未実装。proposed が無限増殖しないよう上限は `max_agent_runs` で間接制御。
+
+### Legacy compatibility
+
+`quest create` に `--solo` を付けると旧ルール (scout/poc が直接 spawn) に戻る。デフォルトは **team モード (owner 付き)**。これにより v1 のテストは `--solo` で通る。
+
+## v3 — Two-phase owner with council (2026-06-24, 設計のみ)
+
+### Motivation
+
+v2 の owner はグラフ編集権を独占するが、**owner 自身の LLM 1出力が bad action なら spawn/promote/abort 全部が曲がる**。owner が SPOF になっている。「1エージェントのミスを防ぐための owner が、owner 自身のミスで止まる」再帰リスクを解消する。
+
+### Two-phase: design + run
+
+owner の1出力を **design phase (協議) + run phase (実行)** の2段に分離:
+
+1. **design phase**: owner は単独で判断せず **council** を招集。council は新ロール `council_member` の N 体(既定3)を**並列**に spawn する。各 member は同じ evidence + proposed を食べて**独立に plan を提案**する。
+2. **run phase**: owner (chair) が複数案を比較・統合し、**1つの merged plan** を出す。tick がその merged plan を機械的に適用する(更なる LLM 呼び出し無し)。
+
+### council_member ロール
+
+```
+Role: council_member
+権限: execute + 提案 のみ (グラフ編集不可)
+入力: 全完了ノード evidence + proposed 一覧 (owner と同じ)
+出力: { "member_id": "A", "confidence": 0.8,
+        "actions": [...], "dissent": "<他案との相違点>" }
+```
+
+- 既定3体。`kage quest new --council-size 5` で変更可
+
+### owner (chair) の2段出力
+
+design phase 完了後、owner は council_members の全案を比較し merged plan を出す:
+
+```json
+{"phase":"run","evidence":"...",
+ "adopted_from":["A","C"], "dissent_handled":"Bは X で却下",
+ "actions":[ {type:promote,...}, ... ]}
+```
+
+- 過半数一致で採用。分裂時は majority + rationale を必ず記録
+- run phase の出力は tick が**機械的に**適用(更なる LLM 呼び出し無し)
+
+### node 状態機械 (v3)
+
+```
+owner (pending)
+  ↓ 待機: _should_dispatch_owner()
+owner (running) ─ design phase
+  ↓ spawn N× council_member (proposed, parallel)
+owner (running) ─ 全 member 完了待ち
+  ↓ chair: merge
+owner (explored) ─ run phase 出力 → tick 適用
+```
+
+新 status: `council_pending` (member 完了待ち)。relation: `council_of` (owner→member), `council_reply` (member→owner)。
+
+### 依存と非実装理由
+
+- **並列実行**: council_members を1 tick 内で並列 spawn するには executor の非同期化が前提。現状 tick は1分1ノード同期のため、並列 council ができない。シリアル council (1 tick 1 member) でも design→run が N+2 tick かかり遅い
+- そのため今回は **intent.md + HTML レポートに設計のみ追記**。executor 並列化が整ったら v3 実装に着手
+
+### schema 予約 (将来)
+
+- `quest_nodes.phase` 列: `design` | `run`
+- `quest_nodes.role`: `council_member` 追加
+- `quests.council_size` 列 (既定3)
+- `quest_edges.relation`: `council_of` / `council_reply` 追加
+
+### Legacy compatibility (v3)
+
+- `--council-size 0` で v2 の単独 owner モードに戻る。テストはこの値で通す
+
+## v3.1 — Looper-informed role design (2026-06-24, 設計のみ)
+
+参考: [ksimback/looper](https://github.com/ksimback/looper) · [looper-spec.md](https://github.com/ksimback/looper/blob/main/looper-spec.md) · [@0xCodez loop engineering](https://x.com/0xCodez/status/2064374643729773029) · [@shannholmberg looper post](https://x.com/shannholmberg/status/2069323309024776456)
+
+### なぜ looper から学ぶか
+
+looper は「設計してから走らせる」層に特化し、council (reviewer / judge) と programmatic 検証で self-grading を排除する。**一人 owner が自前で決めて自前で評価する構造**は、looper が最も批判する「same model grading its own homework」に合致する。kage quest v2 の owner もそれに近く、v3 は looper の区別を取り込む。
+
+### reviewer vs judge (v3.0 の council_member を置き換え)
+
+| ロール | 権限 | 出力 | verdict_source になれるか | 使い所 |
+|--------|------|------|--------------------------|--------|
+| `reviewer` | execute + notes のみ | `{ "notes":[...], "dissent":"..." }` | ❌ なれない | ブレスト、adversarial、視点追加 |
+| `judge` | execute + 構造化 verdict | `{ "verdict":"pass\|revise", "blocking_issues":[...], "confidence":0.0-1.0, "notes":"..." }` | ⭕ なれる | gate 進行を block する判定 |
+| `owner` (chair) | グラフ編集 + gate 運営 | `actions[]` (merge 後) | — | 議長として merge のみ |
+
+- `--council-size N` → `--council "<role>:<count>,..."` 形式へ拡張
+  - 例: `--council "reviewer:2,judge:1"` (既定)
+- `verdict_policy` を導入:
+  - `revise_until_clean`: `verdict_source` が judge/human 必須。reviewer-only は禁止
+  - `fixed_passes`: reviewer notes を N 回適用して proceed (clean 宣言しない)
+- kage v2 の `NODE_STATUS_PROPOSED` は reviewer/judge 共通の「提案」のままでよい。ただし judge は verdict も同時に出し、owner が `verdict_source` 選定に使う
+
+### 明示 gate
+
+looper の `plan_gate` / `delivery_gate` に相当する gate ノードを導入:
+- **scout_gate**: scout のEvidence 蓄積後、poc を走らせる前に reviewer/judge が quality check
+- **poc_gate**: 各 poc 完了後、成長/撤退判定前に judge が verdict
+- **synthesis_gate**: 戦略総括前に reviewer/judge が ROI 視点で verdict
+
+各 gate は `phase` 列で識別。gate ノードは owner が spawn し、`council_members` を relation `council_of` で束ねる。gate の verdict_source が clean を出さない限り、次フェーズの work ノードは pending にならない。
+
+### 検証の型 (programmatic | judge | human)
+
+```yaml
+verification:
+  - id: tests-pass
+    type: programmatic
+    check: ["pytest", "tests/test_quest.py"]
+    expect: exit_zero
+  - id: evidence-enough
+    type: judge
+    rubric: "少なくとも2つの独立した scout/poc evidence が同一方向を示す"
+  - id: human-ok
+    type: human
+    prompt: "Discord で #quest チャンネルに 📌 で同意してください"
+```
+
+- `programmatic`: kage は task runner なので既存 executor で実行可。**無料で deterministic**。looper が最推奨する型
+- `human`: kage の connector (discord/slack/telegram) で consent を取れる。looper の human checkpoint と同じ
+
+### loop_control (暴走防止の拡張)
+
+v2 の `max_agent_runs` だけを置き換えず、looper 互換のガードセットへ:
+
+```yaml
+loop_control:
+  max_iterations: 50          # = max_agent_runs の後方互換
+  budget:
+    tokens: 2_000_000
+    wall_clock_min: 1440       # 24h
+  no_progress:
+    max_stalled_iterations: 3
+    signals:
+      - "同じ blocking issue が繰り返される"
+      - "ノードの evidence が3ラウンド不変"
+      - "proposed が promote されないまま累積"
+    action: stop
+  human_checkpoints: [scout_gate]   # connector 経由で consent
+```
+
+- `no_progress` は looper 由来。kage quest は「動いている間に実質進んでいない」状態を検知する必要がある (owner が堂々巡りすると v2 でも止まらない)
+- `budget.wall_clock_min` は schema 確保済み列 `max_wall_minutes` と統合
+
+### cross-model council (privacy)
+
+```yaml
+council:
+  - id: reviewer-A
+    role: reviewer
+    cli: gemini
+    provider: gemini
+    scope: [scout, poc]
+    privacy:
+      sends: [evidence, proposed]
+      redact: [".env", "secrets/**", "**/*.key"]
+      consent: required
+  - id: judge-B
+    role: judge
+    cli: claude
+    provider: claude
+    scope: [scout_gate, poc_gate]
+    privacy:
+      sends: [evidence, proposed, verdict]
+      consent: required
+```
+
+- host(owner) と別 model family を推奨 (blind-spot coverage)。looper の推奨通り
+- kage 既存の `quest.provider` (host 用) とは別に、council_members は**個別に provider** を持てる
+- cross-vendor への送信は egress 宣言 + consent。kage connector で human approve 可能
+
+### 状態機械 (v3.1)
+
+```
+work ノード(scout/poc/...) 完了
+   ↓
+owner (pending) — _should_dispatch_owner() gate
+   ↓ design phase: gate spawn (scout_gate/poc_gate/...)
+gate (pending)
+   ↓ spawn N× council_member (relation: council_of)
+reviewer/judge (proposed→running→explored)
+   ↓ 各 member verdict/notes
+gate (running) — chair merge
+   ↓ verdict_source が "pass" → 次フェーズ work ノードを pending 化
+   ↓ verdict_source が "revise" → 前フェーズ work ノードを保持し revision spawn
+gate (explored)
+   ↓ run phase: owner が merged actions[] を出し tick が適用
+owner (explored)
+```
+
+新 status: `gate_pending` (member 完了待ち), `gate_revise` (revise 判定で前段差し戻し中)
+新 relation: `council_of`, `council_reply`, `verdict_source_ref`
+
+### kage に残る Non-goal (looper との差)
+
+- looper は「loop 設計をファイルで書き出して hand off」が本質。**kage は設計を SQLite + tick に刻む**ので、loop.yaml/resolved.json 互換ではなく quest rows に正規化する
+- looper の ASCII flow preview 相当は `/quests` Web UI が担う
+- looper は durable orchestrator を明示的に外す。**kage は cron tick を durable orchestrator 代わりに使う**のでここは逆。looper 互換の「設計 JSON を外部 runner に渡す」は将来の `kage quest export` で対応可能
+
+### 実装依存
+
+- council_members の**並列実行**: executor の非同期化が前提 (v3 と同じ)
+- **programmatic check**: 既存 executor で ``TaskDef(command=...)`` を即 dispatch する形で実装可。非同期化不要
+- **human checkpoint**: connector に `quest_consent` source type を追加する小変更で可能
+
+### Legacy compatibility (v3.1)
+
+- `--council ""` で council 無し (v2 の team = owner 単独)
+- `--council "reviewer:0,judge:0"` でも同じ
+- `--solo` で v1
+- 3モード階層: solo → team(v2) → team+council(v3.1)
+
+## v3.2 — Team と社内工程 (planner→executer→accepter) (2026-06-24, 設計のみ)
+
+### 動機
+
+v3.1 までの `scout` / `poc` / `strategist` は「ロール」扱いで、1ノード=1LLM呼出。1回の呼出で「計画も実行も受け入れも同じモデル」になり、looper が批判する same-model-self-grade の構造を Team 内部で再生してしまう。ユーザーの指摘は「ロール→Team に格上げし、Team 内部で工程を分けろ。受け入れテスターが ng なら工程へ差し戻し。accept されて初めて owner に返せ」という階層化。
+
+### 階層構造 (Team = 上位概念)
+
+```
+Owner (1, quest 全体の graph 編集者)
+  │ dispatch work (direction + hypothesis)
+  ▼
+Team: scout / poc / strategist / ...   ← Team はロールではなく編成単位
+  │ Team 内に工程 (stage) を3つ持つ
+  ▼
+  ┌─ planner   (具体タスク分解・計画)
+  │      ↓
+  ├─ executer (実行・証拠生成)
+  │      ↓
+  └─ accepter  (受け入れテスター: pass=ownerへ / ng=planner/executerへ差し戻し)
+```
+
+- **Team** は `scout Team` / `poc Team` / `strategist Team` のように、quest 方向性に沿った「職能チーム」として編成される。owner が「この hypothesis をこの Team に依頼」する単位。
+- **各 Team は工程 (stage) を持つ**: `planner` → `executer` → `accepter`。各 stage は別の member (独立的 LLM 呼出)。
+- **差し戻しループ**: accepter が reject すると planner/executer に戻る。`max_revisions` で暴走防止。cap超過は Team 失敗 verdict を owner に返し、owner が再判断。
+- **accept** された場合のみ、Team は owner に対して構造化 verdict + evidence を returns。
+
+### Team ノード / stage ノード
+
+Quest graph 上で Team を <b>1ノード</b>、各 stage を <b>子ノード</b> で表現:
+
+```
+[parent work node] (owner が spawn)
+  └── Team node (role=team, stage_container)
+        ├── planner node      (role=member, stage=plan)
+        ├── executer node     (role=member, stage=exec)
+        │     ↑↓  (reject で revision loop)
+        └── accepter node     (role=member, stage=accept)
+```
+
+- Team ノード `role` = `team_<kind>` (例: `team_scout`, `team_poc`, `team_strategist`)
+- stage ノード `role` = `member`, 新列 `stage` = `plan|exec|accept`
+- 新 relation: `stages_into` (Team → stage ノード), `rejects_to` (accepter → planner/executer), `accepts_to` (accepter → Team → owner)
+- 新 status: `revising` (差し戻し中), `team_blocked` (max_revisions 超過)
+
+### verdict flow
+
+```
+planner  → implements_plan
+executer → executes, evidence 生成
+accepter → { "verdict": "accept" | "reject",
+             "blocking_issues": [...], "revision_target": "planner|executer",
+             "evidence": "...", "confidence": 0.0-1.0 }
+  accept  → Team verdictSpiel = 完了 + evidence → owner へ
+  reject  → revision_target の stage ノードを再 spawn (relation: rejects_to)
+              agent_runs++ 管理は Team
+```
+
+accepter は looper 互換の `judge` そのもの。Team の `verdict_source` = accepter が担当。これで reviewer-only の clean 宣言問題は解決。
+
+### 各 engineering の粒度 (Team ごと調整可)
+
+Kind は Team により「何を accept とするか」が異なる:
+
+| Team | planner の仕事 | executer の仕事 | accepter の受け入れ基準 | revision target |
+|------|----------------|----------------|--------------------------|-----------------|
+| scout | 検索計画 (ファイル/ログ/外部) | 検索実行 | 「検索計画カバレッジ」と「仮説未解明」をjudge | planner (計画ミス) or executer (実行ミス) |
+| poc | 検証計画 (最小コスト) | スクリプト作成実行実行 | `programmatic` (exit_zero or 指標しきい値) + judge | planner (コスト設計ミス) or executer (実装ミス) |
+| strategist | 評価計画 (ROI軸) | 各ノードevidence を収束出力 | judge (ROI rubric) | planner (軸ミス) or executer (集約ミス) |
+
+- `accepter` は `programmatic`/`judge`/`human` の3種類 (looper 互換)。poc Team は `programmatic` を推奨。
+- `revision_target` は accepter が明示。planner の計画が正しく executer の実行が悪い場合は executer に差し戻し、計画自体が悪い thì planner に戻る — 失敗箇所を局所化。
+
+### council (v3.1) との統合
+
+v3.1 で設計した `reviewer` / `judge` は Team の **accepter** として再利用:
+- Team に `--accept-mode "judge:1"` (judge 1体が accepter) が既定
+- `--accept-mode "reviewer:2,judge:1"` とすると、**reviewer** 2体が「notes のみの reviewer」、**judge** 1体が「verdict 出せる accepter」 (verdict_source)
+- reviewer の notes は planner/executer に feedback として戻り、judge のみが `accept` を出せる (looper の gate rule と互換)
+
+### node 状態機械 (v3.2)
+
+```
+Team node (pending) ← owner dispatch (relation: stages_into)
+  ↓
+planner (proposed→running→explored)
+  ↓ makes_plan
+executer (proposed→running→explored)
+  ↓ executes
+accepter (proposed→running) — judge
+  ├─ accept ─▶ Team (explored) ─▶ owner へ verdictdecken
+  └─ reject ─▶ revision_target (revising) ─▶ planner/executer に戻る
+                            └─▶ max_revisions 超過 → Team (team_blocked) → owner へ fail verdict
+```
+
+新 status: `revising`, `team_blocked`
+新 relation: `stages_into`, `makes_plan`, `executes`, `rejects_to`, `accepts_to`, `verdict_source_ref`
+
+### schema 予約
+
+- `quest_nodes.team_kind`: `scout|poc|strategist|custom` (Team のほうの職能)
+- `quest_nodes.stage`: `plan|exec|accept|revising` (工程)
+- `quest_nodes.revision_count`: 差し戻し回数
+- `quest_nodes.max_revisions`: Team ごと (既定 looper like 3)
+- `quest_edges.relation` に `stages_into`, `makes_plan`, `executes`, `rejects_to`, `accepts_to`
+
+### CLI
+
+```
+kage quest new <name> --direction "..." \
+   [--mode team] \                           # solo|team
+   [--teams "scout,poc,strategist"] \         # Team 編成
+   [--accept-mode "judge:1"] \                # v3.1 verdict_policy 互換
+   [--max-revisions 3] \                      # 工程ごと
+   [--council "reviewer:2,judge:1"]          # accepter 候補メンバー
+```
+
+- `--mode solo`: v1 (直接 spawn)
+- `--mode team` (既定) + `--council ""`: v2 相当 (owner は Team に 工程をスキップして1ノード dispatch する簡易挙動を legacy で提供)
+- `--mode team` + `--council "..."`: v3.2
+
+### 実装依存
+
+- Team 内 stage は**直列**のため executor 非同期化不要。機能する tick に工程を step として乗せられる (planner 1 tick → executer 1 tick → accepter 1 tick)
+- ただし revision loop で「同じ工程が何度も回る」ため、quest が長期化する。これは loop_control.no_progress の出番
+- `accepter` の programmatic check は既存 `TaskDef(command=...)` dispatch で即対応可
+
+### Legacy compatibility (v3.2)
+
+- `--mode solo` で v1 (scout/poc 直接 spawn, 工程なし)
+- `--mode team --council ""` で v2 (owner 単独, Team 内 工程スキップ = 1ノード dispatch)
+- `--mode team --council "..."` で v3.2 (Team + 工程 + council accepter)
+- 4モード階層: solo → team(v2) → team+council(v3.1) → team+stages+council(v3.2)
+
+### デメリット (v3.2 追加分)
+
+- **さらに遅い**: 1 work あたり planner+executer+accepter の最低3 tick (max_revisions 含めると 3+3*revisions)。24h 設計との整合は loop_control で保つ必要
+- **Team ノードと stage ノードで graph が深くなり可視化が煩雑**: `kage ui /quests` で Team 折りたたみ表示が必要
+- **accepter の judge が悪いと無限差し戻し**: `max_revisions` で do not let the host keep revising forever (looper の wisdom)
+- **revision_target 判定の信頼性**: accepter が「planner のせい / executer のせい」を誤判定すると、間違った工程に差し戻されて無駄 revision が増える
+- **ユーザーアクション寮**: quest を新規作るだけで `--teams`, `--accept-mode`, `--council`, `--max-revisions` と項目増。intent 入力の手間が跳ね上がる。将来的には default preset 化が必要

--- a/docs/quest/2026-06-24-quest-lifecycle/report.html
+++ b/docs/quest/2026-06-24-quest-lifecycle/report.html
@@ -1,0 +1,702 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#0b0f14" />
+<title>kage Quest ライフサイクル — 設計レポート</title>
+<style>
+  :root{
+    --bg:#0b0f14; --panel:#121821; --panel2:#0f141b; --line:#1f2a36;
+    --ink:#e8eef6; --dim:#8b9bb0; --faint:#5a6b80;
+    --accent:#5ad1a5; --accent2:#6aa9ff; --warn:#ffb454; --bad:#ff6b6b;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Hiragino Sans,Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0}
+  body{
+    background:radial-gradient(1200px 800px at 80% -10%, #14202b 0%, var(--bg) 55%) fixed;
+    color:var(--ink); font-family:var(--sans); line-height:1.65;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+    padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  }
+  .wrap{max-width:980px;margin:0 auto;padding:8vw 5vw 14vw}
+  @media(min-width:720px){ .wrap{padding:64px 40px 120px} }
+  header.hero{
+    border:1px solid var(--line); background:linear-gradient(180deg,#0e161f, #0b1119);
+    border-radius:18px; padding:28px 22px; margin-bottom:22px;
+    box-shadow:0 10px 40px -20px #000, inset 0 1px 0 #1a2632;
+  }
+  .eyebrow{color:var(--accent); font:600 12px/1 var(--mono); letter-spacing:.18em; text-transform:uppercase}
+  h1{margin:.4em 0 .2em; font-size:clamp(26px,6vw,44px); line-height:1.1; letter-spacing:-.02em}
+  h1 .kage{color:var(--accent)}
+  .lede{margin:.6em 0 0; color:var(--dim); font-size:clamp(14px,3.4vw,17px)}
+  .pillrow{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font:600 11px/1 var(--mono); color:var(--ink); border:1px solid var(--line);
+    padding:7px 10px; border-radius:999px; background:#0c1219}
+  .pill b{color:var(--accent2)}
+  section{
+    background:var(--panel); border:1px solid var(--line); border-radius:16px;
+    padding:22px 18px; margin:0 0 18px;
+  }
+  @media(min-width:720px){ section{padding:30px 30px} }
+  h2{font-size:clamp(18px,4vw,24px); margin:0 0 .4em; letter-spacing:-.01em;
+     display:flex;align-items:center;gap:12px}
+  h2 .n{font:700 12px/1 var(--mono); color:var(--bg); background:var(--accent);
+     border-radius:6px; padding:5px 8px}
+  h3{font-size:15px; margin:1.4em 0 .4em; color:var(--accent2)}
+  p{margin:.5em 0; color:#c6d2e0}
+  .dim{color:var(--dim)}
+  code,kbd{font-family:var(--mono); font-size:.92em;
+    background:#0a1018; border:1px solid var(--line); padding:1px 6px; border-radius:6px}
+  pre{background:#0a0f15; border:1px solid var(--line); border-radius:12px;
+    padding:16px; overflow:auto; font-family:var(--mono); font-size:12.5px; line-height:1.55;
+    color:#cfe3d5}
+  pre .k{color:#9be7c4} pre .s{color:#f5c98b} pre .c{color:#566b80}
+  table{border-collapse:collapse; width:100%; font-size:13px}
+  th,td{text-align:left; padding:9px 10px; border-bottom:1px solid var(--line)}
+  th{color:var(--accent2); font-weight:600; font-family:var(--mono); font-size:11px; letter-spacing:.06em}
+  td code{white-space:nowrap}
+  .grid{display:grid; gap:14px}
+  @media(min-width:640px){ .grid.cols-2{grid-template-columns:1fr 1fr} }
+  .card{border:1px solid var(--line); border-radius:12px; background:var(--panel2);
+    padding:16px}
+  .card h4{margin:0 0 6px; font-size:14px; color:var(--accent)}
+  .card p{margin:.3em 0; font-size:13px; color:#b9c6d6}
+  canvas{display:block; width:100%; height:auto; border:1px solid var(--line);
+    border-radius:12px; background:#0a0f15}
+  .legend{display:flex;flex-wrap:wrap; gap:14px; font-size:12px; color:var(--dim);
+    margin-top:10px}
+  .legend i{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:6px;vertical-align:middle}
+  .badge{display:inline-block;font:600 10px/1 var(--mono);padding:4px 7px;border-radius:5px;border:1px solid var(--line)}
+  .b-accent{color:var(--accent);border-color:#1d4a39} .b-blue{color:var(--accent2);border-color:#1a3a63}
+  .b-warn{color:var(--warn);border-color:#553a17} .b-bad{color:var(--bad);border-color:#4e1f1f}
+  .flow{display:flex;flex-wrap:wrap;align-items:stretch;gap:0;margin:8px 0 4px}
+  .flow .step{flex:1 1 140px;background:var(--panel2);border:1px solid var(--line);
+    border-radius:10px;padding:12px;margin:0 6px 6px 0;position:relative}
+  .flow .step::after{content:"→"; position:absolute; right:-14px; top:50%; transform:translateY(-50%);
+    color:var(--faint); font-size:18px}
+  .flow .step:last-child::after{content:""}
+  .flow .step h5{margin:0 0 4px;font-size:13px;color:var(--accent)}
+  .flow .step p{margin:0;font-size:12px;color:var(--dim)}
+  footer{color:var(--faint);font-size:12px;text-align:center;margin-top:24px}
+  ul{padding-left:1.2em} li{margin:.3em 0;color:#c6d2e0}
+  .tag{font:600 11px/1 var(--mono);color:var(--accent2)}
+  a{color:var(--accent2)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="hero">
+  <div class="eyebrow">kage 影 · 設計レポート · 2026-06-24</div>
+  <h1><span class="kage">Quest</span> ライフサイクル</h1>
+  <p class="lede">cron の”決まった時間に決まったタスク”を超えて、<b>流動的・セレンディピティがある組織的な AI 探索</b>を 24 時間 自律稼働させるための第2のライフサイクル。マインドマップ状のタスクグラフ、POC 撤退/育成、そして暴走防止の予算。</p>
+  <div class="pillrow">
+    <span class="pill">event-driven · <b>1 cron tick → 1 node</b></span>
+    <span class="pill">team roles · <b>scout / poc / strategist</b></span>
+    <span class="pill">graph · <b>nodes + edges</b></span>
+    <span class="pill">runaway guard · <b>max_agent_runs</b></span>
+    <span class="pill">OS-native · <b>no daemon</b></span>
+  </div>
+</header>
+
+<section>
+  <h2><span class="n">01</span>背景と課題</h2>
+  <p>現在の kage は <b>cron</b> ベースのみ。1タスク=1プロンプトを決まった時刻に起動し、Memory で線形に状態を保つ。人間のリアルな仕事――<span class="dim">"ぼんやりした方向"から 0 で現状を調べ、PoC を回し、ROI で撤退/拡大を繰り返す</span>――とは質が違う。</p>
+  <div class="grid cols-2">
+    <div class="card">
+      <h4>cron ライフサイクル</h4>
+      <p>・固定スケジュール<span class="dim">/線形 checklist</span></p>
+      <p>・1エージェント・1プロンプト</p>
+      <p>・"小さく決まったことを回す"用途</p>
+    </div>
+    <div class="card">
+      <h4>quest ライフサイクル <span class="b-accent">new</span></h4>
+      <p>・方向性だけ与えて継続探索</p>
+      <p>・ロール毎のチーム即時編成</p>
+      <p>・グラフ探索 + 撤退/育成のループ</p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <h2><span class="n">02</span>全体アーキテクチャ</h2>
+  <canvas id="cnvArch" width="940" height="440" aria-label="アーキテクチャ図"></canvas>
+  <div class="legend">
+    <span><i style="background:#4ec9a0"></i>OS ネイティブ (既存)</span>
+    <span><i style="background:#6aa9ff"></i>quest (今回追加)</span>
+    <span><i style="background:#ffb454"></i>共通の executor / runs</span>
+  </div>
+  <p class="dim" style="font-size:12px;margin-top:8px">cron と quest は同じ <code>kage cron run</code> 1分 tick に乗り、<b>新しく常駐プロセスは立たない</b>。quest のノード実行は既存の <code>executor.execute_task</code> を再利用するため、run 履歴 / log / metadata が cron と同一。</p>
+</section>
+
+<section>
+  <h2><span class="n">03</span>4つのロール = 総合力チーム (v2)</h2>
+  <div class="flow">
+    <div class="step"><h5>owner 👑 (NEW)</h5><p><b>唯一のグラフ編集者</b>。証拠が揃わない限り動かない。<span class="tag">promote / abort / spawn / finish</span></p></div>
+    <div class="step"><h5>scout 🧭</h5><p>現状リサーチ。仮説を<b>提案</b>のみ。直接子 spawn はしない。<span class="tag">proposed 留め</span></p></div>
+    <div class="step"><h5>poc 🧪</h5><p>最小検証。verdict は<b>提案</b>。owner 判断待ち。<span class="tag">proposed 留め</span></p></div>
+    <div class="step"><h5>strategist ♟</h5><p>ROI 提案。判断は owner。<span class="tag">proposed 留め</span></p></div>
+  </div>
+  <p class="dim" style="font-size:12px">v2 では ロールは Quest 作成時に宣言。デフォルト (team モード) <code>scout,poc,strategist,owner</code>。各ロールは provider + プロンプト雛形を持ち、実行時に具体化。<code>--solo</code> でv1動作(scout/pocが直接spawn)に戻る。<code>--provider claude</code> 等でチーム単位の AI 指定も可。</p>
+</section>
+
+<section>
+  <h2><span class="n">04</span>マインドマップ = タスクグラフ</h2>
+  <p>直線的なチェックリストではなく、<b>親から子へ枝分かれ</b>し、死んだ枝は <code>aborted</code>、有望な枝は <code>grew_to</code> で延伸。<span class="badge b-blue">SQLite</span> の 3 テーブルで永続化。</p>
+  <canvas id="cnvGraph" width="940" height="380" aria-label="task graph example"></canvas>
+  <div class="legend">
+    <span><i style="background:#5ad1a5"></i>探索済/成長中 (explored/growing)</span>
+    <span><i style="background:#ff6b6b"></i>撤退 (aborted · dead PoC)</span>
+    <span><i style="background:#ffb454"></i>実行中 (running)</span>
+    <span><i style="background:#3a4858"></i>保留 (pending)</span>
+  </div>
+  <h3>ノードのライフサイクル</h3>
+  <pre><span class="c"># pending → run → {explored | growing | aborted}</span>
+pending  → running → explored   <span class="c"># 結論のみ・分岐なし</span>
+pending  → running → growing    <span class="c"># promising → 子 poc を展開</span>
+pending  → running → aborted   <span class="c"># dead → strategist を spawn</span></pre>
+</section>
+
+<section>
+  <h2><span class="n">05</span>1 分 tick の中身</h2>
+  <canvas id="cnvTick" width="940" height="360" aria-label="tick ループ"></canvas>
+  <p>アクティブな quest ごとに <b>最大1ノード</b> を dispatch。実行は同期待ちで <code>execute_task</code> に乗せ、完了後に verdict JSON を parse して子ノード/エッジを生成。<code>agent_runs</code> を +1。</p>
+  <h3>AI との出力契約 (Output contract)</h3>
+  <pre><span class="k">```json</span>
+{ <span class="s">"verdict"</span>: <span class="s">"promising (有望)" | "dead (撤退)"</span>,
+  <span class="s">"evidence"</span>: <span class="s">"&lt;要約&gt;"</span>,
+  <span class="s">"new_directions"</span>: [<span class="s">"&lt;次に試す仮説&gt;"</span>, ...] }
+<span class="k">```</span></pre>
+</section>
+
+<section>
+  <h2><span class="n">06</span>暴走防止 — 終了条件</h2>
+  <table>
+    <thead><tr><th>条件</th><th>既定</th><th>状態</th><th></th></tr></thead>
+    <tbody>
+      <tr><td><code>max_agent_runs</code></td><td>50</td><td>超過で <span class="badge b-bad">terminated</span></td><td><span class="badge b-accent">今回実装</span></td></tr>
+      <tr><td><code>max_wall_minutes</code></td><td>—</td><td>開始からの経過時間上限</td><td><span class="badge">将来 (列は用意済み)</span></td></tr>
+      <tr><td><code>max_token_budget</code></td><td>—</td><td>概算 token / 呼び出し回数</td><td><span class="badge">将来</span></td></tr>
+      <tr><td>人間ゲート</td><td>—</td><td>深度/転換時に connector 経由で承認</td><td><span class="badge">将来</span></td></tr>
+      <tr><td><code>kage quest stop &lt;id&gt;</code></td><td>—</td><td>手動停止 (tick は skip)</td><td><span class="badge b-accent">今回</span></td></tr>
+      <tr><td><code>kage quest abort-node &lt;id&gt;</code></td><td>—</td><td>単一ノード強制 abort</td><td><span class="badge b-accent">今回</span></td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <h2><span class="n">07</span>データモデル</h2>
+  <div class="grid cols-2">
+    <div>
+      <h3>quests</h3>
+      <pre><span class="c">id, project_path, name, direction,
+status <span class="k">(active|done|terminated|stopped)</span>,
+max_agent_runs, agent_runs,
+roles_json, provider, created_at, updated_at</span></pre>
+    </div>
+    <div>
+      <h3>quest_nodes</h3>
+      <pre><span class="c">id, quest_id, parent_id, role,
+hypothesis,
+status <span class="k">(pending|running|explored|
+       aborted|growing)</span>,
+verdict, evidence, run_id,
+created_at, updated_at</span></pre>
+    </div>
+  </div>
+  <h3>quest_edges</h3>
+  <pre><span class="c">id, quest_id, from_node, to_node,
+relation <span class="k">(spawned|aborted_to|grew_to)</span>, created_at</span></pre>
+</section>
+
+<section>
+  <h2><span class="n">08</span>CLI</h2>
+  <pre>kage quest new &lt;name&gt; --direction <span class="s">"..."</span> \
+            [--roles scout,poc,strategist] [--max-agent-runs 50] \
+            [--provider claude] [--project &lt;path&gt;]
+kage quest list        <span class="c"># id / 名前 / 状態 / runs / ノード数</span>
+kage quest show &lt;id&gt;   <span class="c"># ノード + エッジ表で表示</span>
+kage quest stop &lt;id&gt;
+kage quest resume &lt;id&gt;
+kage quest abort-node &lt;node_id&gt;</pre>
+  <p class="dim" style="font-size:12px">quest 実行は既存の <code>kage runs</code> / <code>kage logs</code> にもそのまま載る。task 名は <code>quest:&lt;quest_id&gt;:&lt;node_id&gt;</code>。</p>
+</section>
+
+<section>
+  <h2><span class="n">09</span>ざっくり使ってみる</h2>
+  <pre>kage quest new ocr-hunt \
+  --direction <span class="s">"日本語請求書PDF向けの無料OCRで最大精度を探す"</span> \
+  --max-agent-runs 80 --provider claude
+<span class="c"># あとは寝る。1分ごとに scout→poc→... が回り、</span>
+<span class="c"># 朝には死んだ枝が abort され、有望枝が grow した状態で記録される。</span>
+kage quest list
+kage quest show &lt;id&gt;     <span class="c"># グラフ＋検証結果を一覧</span>
+kage runs                 <span class="c"># quest の各ノードもここに並ぶ</span></pre>
+</section>
+
+<section>
+  <h2><span class="n">15</span>v3.2 設計: Team と工程 (planner→executer→accepter)</h2>
+  <p>ユーザー指摘: scout/poc は「ロール」より<b>Team</b>という上位概念で持て。Team 内で <code>planner → executer → accepter (受け入れテスター)</code> の工程を回し、accepter が ng なら工程へ差し戻し。accept されたら初めて owner へ返せ。</p>
+  <h3>階層構造</h3>
+  <canvas id="cnvTeam" width="940" height="380" aria-label="team hierarchy diagram"></canvas>
+  <p class="dim" style="font-size:12px">Team は1ノード、各工程は子ノード。Teamは<b>編成単位</b>、工程は<b>社内 pipeline</b>。owner は Team に dispatch し、Team は accept されたとき初めて owner に verdict を返す。</p>
+  <h3>工程ごとの役割</h3>
+  <table>
+    <thead><tr><th>工程 (stage)</th><th>役割</th><th>出力</th></tr></thead>
+    <tbody>
+      <tr><td><code>planner</code></td><td>hypothesis を具体タスクに分解・計画</td><td><code>implements_plan</code></td></tr>
+      <tr><td><code>executer</code></td><td>計画に沿って実行・証拠生成</td><td><code>evidence</code></td></tr>
+      <tr><td><code>accepter</code></td><td>受け入れテスト (looper 互換 judge)</td><td><code>{verdict:"accept\|reject", revision_target:"planner\|executer"}</code></td></tr>
+    </tbody>
+  </table>
+  <h3>差し戻しループ</h3>
+  <pre>planner ─▶ executer ─▶ accepter
+   ↑                         │
+   └── <span class="c"># reject (revision_target=planner)</span>
+        ↑
+        └── executer だけ差し戻し (revision_target=executer) も可
+
+accept ─▶ Team 完了 verdict ─▶ owner へ
+reject は <b>max_revisions</b> で暴走防止
+cap 超過 ─▶ Team <code>team_blocked</code> ─▶ owner に fail verdict → 再判断</pre>
+  <p class="dim" style="font-size:12px">accepter は looper の <code>judge</code> と同じ。reviewer は notes のみ。reviewer-only は clean 宣言できない (looper gate rule 互換)。</p>
+  <h3>Team ごとの accept 基準</h3>
+  <table>
+    <thead><tr><th>Team</th><th>accepter が使う検証型</th><th>revision_target 判断</th></tr></thead>
+    <tbody>
+      <tr><td><code>scout</code></td><td>judge (検索カバレッジ + 仮説未解明)</td><td>planner (計画ミス) / executer (実行ミス)</td></tr>
+      <tr><td><code>poc</code></td><td><b>programmatic</b> (exit_zero/指標しきい値) + judge</td><td>planner (コスト設計ミス) / executer (実装ミス)</td></tr>
+      <tr><td><code>strategist</code></td><td>judge (ROI rubric)</td><td>planner (評価軸ミス) / executer (集約ミス)</td></tr>
+    </tbody>
+  </table>
+  <h3>verdict flow</h3>
+  <pre>Team (pending) ← owner.dispatch (stages_into)
+planner (proposed→running→explored) ─makes_plan→ executer
+executer (proposed→running→explored) ─executes→ accepter
+accepter (running) ─ judge
+  ├─ accept ─▶ Team (explored) ─▶ owner へ verdict 返却
+  └─ reject ─▶ revision_target (revising) ─▶ planner/executer 差し戻し
+                max_revisions 超過 → team_blocked → owner に fail</pre>
+  <h3>schema 予約</h3>
+  <pre>quest_nodes.team_kind: scout|poc|strategist|custom
+quest_nodes.stage: plan|exec|accept|revising
+quest_nodes.revision_count, max_revisions
+quest_edges.relation: stages_into, makes_plan, executes,
+                       rejects_to, accepts_to</pre>
+  <h3>4モード階層 (互換性)</h3>
+  <ul>
+    <li><code>--mode solo</code>: v1 (直接 spawn, 工程なし)</li>
+    <li><code>--mode team --council ""</code>: v2 (owner 単独, 工程 skip の簡易)</li>
+    <li><code>--mode team --council "reviewer:2,judge:1"</code>: v3.1 (council)</li>
+    <li><code>--mode team --council "..."</code>: <b>v3.2 (Team + 工程 + council accepter)</b></li>
+  </ul>
+  <h3>デメリット (追加分)</h3>
+  <ul>
+    <li><b>さらに遅い</b>: 1 work で planner+executer+accepter の最低3 tick。revision 含めると 3+3*rev。24h と loop_control で整合必須</li>
+    <li><b>graph が深くなり可視化が煩雑</b>: <code>kage ui /quests</code> で Team 折りたたみ表示が必須</li>
+    <li><b>accepter 判定ミスで無駄 revision</b>: revision_target を誤ると間違った工程に差し戻し。<code>max_revisions</code> キャップ必須</li>
+    <li><b>CLI 設定項目増</b>: <code>--teams / --accept-mode / --council / --max-revisions</code>。preset 化が必要</li>
+  </ul>
+</section>
+
+<section>
+  <h2><span class="n">14</span>v3.1 設計: looper から学んだ role 設計</h2>
+  <p>参考: <a href="https://github.com/ksimback/looper" target="_blank">ksimback/looper</a> · <a href="https://x.com/0xCodez/status/2064374643729773029" target="_blank">@0xCodez loop engineering</a> · <a href="https://x.com/shannholmberg/status/2069323309024776456" target="_blank">@shannholmberg looper</a></p>
+  <p>looper は「設計 → 実行」の2層 + council (reviewer/judge) + programmatic検証 で「same model grading its own homework」を排除する。kage v2 の owner 単独はまさにその blind spot で、v3 は区別を取り込む。</p>
+  <h3>reviewer vs judge (council_member を置き換え)</h3>
+  <table>
+    <thead><tr><th>Role</th><th>出力</th><th>verdict_source</th><th>用途</th></tr></thead>
+    <tbody>
+      <tr><td><code>reviewer</code></td><td><code>{"notes":[...], "dissent":"..."}</code></td><td>❌ なれない</td><td>ブレスト / 視点追加</td></tr>
+      <tr><td><code>judge</code></td><td><code>{"verdict":"pass|revise", "blocking_issues":[...], "confidence":0.82}</code></td><td>⭕ なれる</td><td>gate を block する判定</td></tr>
+      <tr><td><code>owner</code> (chair)</td><td><code>actions[]</code> (merge 後)</td><td>—</td><td>議長として merge のみ</td></tr>
+    </tbody>
+  </table>
+  <p class="dim" style="font-size:12px"><code>--council "reviewer:2,judge:1"</code> 形式で構成。reviewer-only gate は <code>fixed_passes</code> のみ。clean 宣言は禁止。</p>
+  <h3>3つの検証 type (looper 互換)</h3>
+  <pre>programmatic: <span class="c"># 無料・deterministic</span>
+  check: ["pytest", "tests/test_quest.py"], expect: exit_zero
+judge: <span class="c"># rubric + 構造化 verdict</span>
+  rubric: "少なくとも2つの独立 evidence が同方向"
+human: <span class="c"># kage connector 経由で consent</span>
+  prompt: "Discord で 📌 で同意"</pre>
+  <h3>明示 gate (scout/poc/synthesis)</h3>
+  <div class="flow">
+    <div class="step"><h5>scout_gate</h5><p>scout evidence 蓄積後、poc前にreviewer/judgeがquality check</p></div>
+    <div class="step"><h5>poc_gate</h5><p>各poc完了後、成長/撤退判定前にjudgeがverdict</p></div>
+    <div class="step"><h5>synthesis_gate</h5><p>戦略総括前にreviewer/judgeがROI視点</p></div>
+  </div>
+  <h3>loop_control 拡張 (暴走防止)</h3>
+  <pre>max_iterations: 50          <span class="c"># = max_agent_runs 後方互換</span>
+budget:
+  tokens: 2_000_000
+  wall_clock_min: 1440       <span class="c"># 24h (既存 max_wall_minutes 列に統合)</span>
+no_progress:
+  max_stalled_iterations: 3
+  signals: [<span class="s">"同じ issue が繰り返し"</span>, <span class="s">"evidence 3ラウンド不変"</span>]
+  action: stop
+human_checkpoints: [scout_gate]   <span class="c"># connector 経由</span></pre>
+  <p class="dim" style="font-size:12px">v2 の <code>max_agent_runs</code> だけでは「動いている間に実質進んでいない」堂々巡りを検知できない。<code>no_progress</code> が looper 由来でその穴を埋める。</p>
+  <h3>cross-model council (privacy)</h3>
+  <pre>host(owner):  claude     <span class="c"># kage quest.provider</span>
+reviewer-A:   gemini     <span class="c"># 別 family 推奨 (blind spot)</span>
+judge-B:      codex      <span class="c"># gate 判定</span>
+<span class="c"># privacy.egress: 別 vendor CLI 送信を明示 + consent + redact glob</span></pre>
+  <p class="dim" style="font-size:12px">council_members は quest 単位の <code>provider</code> とは<b>個別に provider</b> を持てる。</p>
+  <h3>状態機械 (v3.1)</h3>
+  <pre>work(scout/poc) 完了
+  ↓ owner (pending) — _should_dispatch_owner() gate
+  ↓ design: gate spawn (scout_gate / poc_gate / ...)
+gate (pending)
+  ↓ spawn N× reviewer/judge (relation: council_of)
+member (proposed→running→explored)
+  ↓ verdict / notes
+gate (running) — chair merge
+  ↓ verdict_source "pass" → 次フェーズ work を pending 化
+  ↓ verdict_source "revise" → 前フェーズ work を保持し revision spawn
+gate (explored)
+  ↓ run: owner が merged actions[] → tick 適用
+owner (explored)</pre>
+  <h3>3モード階層 (互換性)</h3>
+  <ul>
+    <li><code>--solo</code>: v1 (scout/poc 直接 spawn)</li>
+    <li><code>--council ""</code>: v2 (owner 単独)</li>
+    <li><code>--council "reviewer:2,judge:1"</code>: v3.1 (council 付き team)</li>
+  </ul>
+  <p class="dim" style="font-size:12px">今回は intent + 本レポートに設計のみ。executor 並列化と connector consent 拡張後に着手。programmatic check / loop_control 拡張は非同期化なしでも実装可能。</p>
+</section>
+
+<section>
+  <h2><span class="n">13</span>v3 設計: design + run 2-phase で owner SPOF 解消</h2>
+  <p>v2 では <b>owner 1出力が曲がればグラフ全体が曲がる</b> SPOF だった。v3 は owner を design (協議) + run (実行) の2フェーズに分け、design phase で <b>council</b> を並列招集して再帰リスクを下げる。</p>
+  <div class="grid cols-2">
+    <div class="card">
+      <h4>design phase (協議)</h4>
+      <p>owner は判断せず council_member N 体を<b>並列</b> spawn</p>
+      <p>各 member が独立 LLM 呼出で plan を提案</p>
+      <p>owner (chair) が複数案を比較し merged plan を1つ統合</p>
+      <p class="dim">過半数一致で採用。分裂時は rationale 記録</p>
+    </div>
+    <div class="card">
+      <h4>run phase (実行)</h4>
+      <p>merged plan を tick が<b>機械的に</b>適用</p>
+      <p>run phase では追加 LLM 呼出なし</p>
+      <p>→ owner LLM 1回分の依存を解消</p>
+      <p class="dim">bad plan を出すには N+1 体が同時に間違える必要</p>
+    </div>
+  </div>
+  <h3>council_member ロール (新)</h3>
+  <pre>Role: council_member   権限: execute + 提案のみ (graf 編集不可)
+入力: 全 evidence + proposed 一覧 (owner と同一)
+出力: { "member_id":"A", "confidence":0.8, "actions":[...], "dissent":"..." }
+既定3体 (--council-size N で変更可)</pre>
+  <h3>2-phase 状態機械</h3>
+  <pre>owner (pending)  ← _should_dispatch_owner() 待機
+   ↓
+owner (running)   ─ design phase ─▶ spawn N × council_member (並列, proposed)
+   ↓                        owner は全 member 完了待ち (status: council_pending)
+owner (running)   ─ chair: merge
+   ↓
+owner (explored)  ─ run phase 出力 → tick 適用 (機械的)</pre>
+  <p class="dim" style="font-size:12px">→ 新 status: <code>council_pending</code> / 新 relation: <code>council_of</code> (owner→member), <code>council_reply</code> (member→owner) / 新列: <code>quest_nodes.phase</code> (design|run) / <code>--council-size 0</code> で v2 単独 owner に戻る</p>
+  <h3>なぜ今回は設計だけか</h3>
+  <ul>
+    <li>並列 council には <b>executor の非同期化</b>が前提。現状は1分・1ノード同期</li>
+    <li>シリアル council だと design→run で N+2 tick かかり、遅さが v2 より悪化</li>
+    <li>そのため intent + 本レポートに設計のみ追記。executor 並列化後に着手</li>
+  </ul>
+</section>
+
+<section>
+  <h2><span class="n">11</span>v2: Owner-gated team model</h2>
+  <p>v1 では scout/poc が promising 判定のたびに <b>勝手に子ノードを spawn</b> していた。LLM 1 個のミスが即グラフに漏れる構造で、「1エージェントはまだミスが多い」限界を捨てきれない。</p>
+  <div class="grid cols-2">
+    <div class="card">
+      <h4>v1: solo (勝手に進む)</h4>
+      <p>scout が promising → 直接 poc を spawn</p>
+      <p>poc が dead → 直接 strategist を spawn</p>
+      <p>1エージェント = グラフの所有者</p>
+      <p class="dim">→ 簡単だがミスが直結</p>
+    </div>
+    <div class="card">
+      <h4>v2: team (owner だけ触れる)</h4>
+      <p><b>owner</b> だけがグラフ編集権を持つ (唯一)</p>
+      <p>scout/poc/strategist は <b>proposed</b> ノード(提案)のみ生成。即 spawn しない</p>
+      <p>owner は十分な証拠が溜まるまで<b>動かない</b> (<code>_should_dispatch_owner</code> gate)</p>
+      <p>owner 出力 = <code>actions[]</code>: <code>promote / abort / spawn / finish</code></p>
+      <p>tick が action を権限チェック付きで適用。未知 ID は弾く</p>
+    </div>
+  </div>
+  <h3>proposed ノードのライフ</h3>
+  <pre><span class="c"># scout/poc/strategist が実行 → proposed を残す</span>
+SCOUT POC  ──execute──▶ proposed (by scout)
+                          │
+                          │ owner が promote で pending 化
+                          ▼
+                       pending ──▶ running ──▶ explored/growing/aborted
+                                               │
+                                               └▶ owner が次ラウンドで triage</pre>
+  <p class="dim" style="font-size:12px">→ <code>proposed_by</code> 列 & <code>proposed_from</code> エッジで誰の提案か追跡可能。owner は全 evidence を食べて総合判断。「1人で進めるのはダメ、チームで戦う」を機構として保証。</p>
+</section>
+
+<section>
+  <h2><span class="n">12</span>v2: Web UI — kage ui /quests</h2>
+  <p><code>kage ui</code> に quest 専用ページを追加。PC・スマホ両方で LAN から確認できる。</p>
+  <pre>kage ui --host 0.0.0.0 --port 8771
+<span class="c"># スマホ: http://&lt;raspiのIP&gt;:8771/quests</span></pre>
+  <h3>追加 route</h3>
+  <ul>
+    <li><code>GET /quests</code> — quest 一覧 + 個別グラフ描画 SPA ページ</li>
+    <li><code>GET /api/quests</code> — 全 quest JSON (status / runs / roles / mode / node_counts)</li>
+    <li><code>GET /api/quests/{id}</code> — ノード + エッジ + verdict / evidence 詳細</li>
+  </ul>
+  <p>ページ機能:</p>
+  <ul>
+    <li>クエストカード一覧 (status badge / runs / node 数)</li>
+    <li>クリックで SVG グラフ描画 (layered tree): 色=status, 点線=proposed, 王冠=owner, 矢印=relation 別色</li>
+    <li>Nodes / Edges テーブル (verdict, evidence, proposed_by 表示)</li>
+    <li>5 秒間隔で自動リロード <span class="dim">(進行状況がほぼリアルタイムで見える)</span></li>
+  </ul>
+</section>
+
+<section>
+  <h2><span class="n">10</span>実装スコープ &amp; 残課題</h2>
+  <div class="grid cols-2">
+    <div class="card">
+      <h4>今回やったこと (v1+v2)</h4>
+      <ul>
+        <li>設計 doc: <code>docs/quest/.../intent.md</code> (v1 + v2 section)</li>
+        <li>DB schema (3 テーブル + <code>mode</code>/<code>proposed_by</code> 列)</li>
+        <li><code>src/kage/quest.py</code>: QuestMode, owner-gated spawn, action 適用</li>
+        <li>scheduler 末尾に <code>quest_tick()</code> 接続</li>
+        <li><code>kage quest</code> サブコマンド (<code>--solo</code> 付き)</li>
+        <li>Web UI: <code>/quests</code> + <code>/api/quests</code></li>
+        <li>テスト 9 件 / ruff pass / 162 tests green</li>
+        <li>README / README_JA / SKILL.md / HTML レポート更新</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h4>将来 (intent に設計済み)</h4>
+      <ul>
+        <li>wall-clock / token 予算の実装</li>
+        <li>connector 経由の人間承認ゲート</li>
+        <li>owner action の厳密 validation</li>
+        <li>proposed 自動間引き (今は上限で間接制御)</li>
+        <li>TUI でのグラフ表示 (現在は Web のみ)</li>
+        <li><code>kage doctor</code> への quest 診断行</li>
+        <li>ロール プロンプトの quest 単位上書き</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<footer>
+  kage · Quest ライフサイクル プロトタイプ · 2026-06-24 · このページは RasPi から LAN 向けに配信
+</footer>
+
+</div>
+
+<script>
+// ---------- tiny canvas helpers ----------
+function fitCanvas(c){
+  const dpr = Math.min(window.devicePixelRatio||1, 2);
+  const r = c.getBoundingClientRect();
+  c.width = Math.round(r.width*dpr);
+  const H = c.getAttribute('height')|0;
+  c.height = Math.round(H*dpr);
+  c.style.height = H+'px';
+  const ctx = c.getContext('2d'); ctx.setTransform(dpr,0,0,dpr,0,0);
+  return ctx;
+}
+function node(ctx,x,y,r,fill,stroke='#1f2a36'){
+  ctx.beginPath(); ctx.arc(x,y,r,0,7); ctx.fillStyle=fill; ctx.fill();
+  ctx.strokeStyle=stroke; ctx.lineWidth=1.5; ctx.stroke();
+}
+function label(ctx,x,y,t,color='#c6d2e0',size=12,align='center'){
+  ctx.fillStyle=color; ctx.font=`${size}px ui-monospace,monospace`;
+  ctx.textAlign=align; ctx.textBaseline='middle'; ctx.fillText(t,x,y);
+}
+function arrow(ctx,x1,y1,x2,y2,color='#3a4858',dash=[]){
+  ctx.strokeStyle=color; ctx.fillStyle=color; ctx.lineWidth=1.5;
+  ctx.setLineDash(dash); ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2); ctx.stroke();
+  ctx.setLineDash([]);
+  const a=Math.atan2(y2-y1,x2-x1), s=7;
+  ctx.beginPath(); ctx.moveTo(x2,y2);
+  ctx.lineTo(x2-s*Math.cos(a-.4), y2-s*Math.sin(a-.4));
+  ctx.lineTo(x2-s*Math.cos(a+.4), y2-s*Math.sin(a+.4));
+  ctx.closePath(); ctx.fill();
+}
+function box(ctx,x,y,w,h,fill='#0f141b',stroke='#1f2a36',r=10){
+  ctx.beginPath();
+  ctx.moveTo(x+r,y); ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r);
+  ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); ctx.closePath();
+  ctx.fillStyle=fill; ctx.fill(); ctx.strokeStyle=stroke; ctx.lineWidth=1.5; ctx.stroke();
+}
+function multi(ctx,x,y,w,h,lines){
+  box(ctx,x,y,w,h);
+  ctx.textAlign='center'; ctx.textBaseline='middle';
+  const lh=16, sy=y+h/2 - (lines.length-1)*lh/2;
+  lines.forEach((ln,i)=>{
+    if(ln.i){ctx.fillStyle=ln.i; ctx.font='600 12px ui-monospace,monospace';}
+    else    {ctx.fillStyle=ln.c||'#e8eef6'; ctx.font='13px -apple-system,sans-serif';}
+    ctx.fillText(ln.t, x+w/2, sy+i*lh);
+  });
+}
+
+// ---------- 02 architecture ----------
+(function(){
+  const c=document.getElementById('cnvArch'); const ctx=fitCanvas(c);
+  const W=c.clientWidth, H=parseInt(c.style.height);
+  // top bar: OS scheduler
+  box(ctx, W*.5-150, 20, 300, 48, '#0c1a22');
+  label(ctx,W*.5,44,'cron / launchd · 1分毎','#5ad1a5',13);
+  // arrow down to kage cron run
+  arrow(ctx,W*.5,68, W*.5,100,'#9fb3c8');
+  box(ctx,W*.5-150,100,300,44); label(ctx,W*.5,122,'kage cron run (1分tick)','#e8eef6',14);
+  // branch to cron + quest
+  arrow(ctx,W*.5-120,144, W*.5-220,200,'#9fb3c8');
+  arrow(ctx,W*.5+120,144, W*.5+220,200,'#6aa9ff');
+  // cron side
+  box(ctx,W*.5-300,200,200,90,'#0e1419');
+  multi(ctx,W*.5-300,200,200,90,[
+    {t:'cron ライフサイクル',i:'#5ad1a5'},
+    {t:'tasks/*.md',c:'#8b9bb0'},
+    {t:'cron式で should_run',c:'#8b9bb0'},
+  ]);
+  // quest side (new)
+  box(ctx,W*.5+100,200,200,90,'#0c1626');
+  multi(ctx,W*.5+100,200,200,90,[
+    {t:'quest ライフサイクル  NEW',i:'#6aa9ff'},
+    {t:'active な quest',c:'#8b9bb0'},
+    {t:'1 tick = 1 ノード',c:'#8b9bb0'},
+  ]);
+  // merge into executor
+  arrow(ctx,W*.5-200,290, W*.5-60,340,'#ffb454');
+  arrow(ctx,W*.5+200,290, W*.5+60,340,'#ffb454');
+  box(ctx,W*.5-160,340,320,52,'#1a1308');
+  multi(ctx,W*.5-160,340,320,52,[
+    {t:'executor.execute_task (共通)',i:'#ffb454'},
+  ]);
+  label(ctx,W*.5,H-14,'runs · logs · metadata · kage runs / kage logs で一元参照','#5a6b80',11);
+})();
+// ---------- 04 graph example ----------
+(function(){
+  const c=document.getElementById('cnvGraph'); const ctx=fitCanvas(c);
+  const W=c.clientWidth, H=parseInt(c.style.height);
+  const C={ok:'#3a6b58',grow:'#1d4a39',bad:'#4e1f1f',pend:'#26323f',run:'#553a17'};
+  // owner at top
+  node(ctx,W*.5,H*.12,26,'#3a2a6e'); label(ctx,W*.5,H*.12-2,'owner 👑','#d2a8ff',12);
+  // scout proposed (violet dashed)
+  node(ctx,W*.22,H*.42,22,'#3a2a6e'); label(ctx,W*.22,H*.42-2,'scout 提案','#d2a8ff',10);
+  // poc grown
+  node(ctx,W*.60,H*.42,22,'#1d4a39'); label(ctx,W*.60,H*.42-2,'poc 有望','#5ad1a5',11);
+  node(ctx,W*.85,H*.42,22,'#4e1f1f'); label(ctx,W*.85,H*.42-2,'poc 撤退','#ff6b6b',11);
+  // grandchildren
+  node(ctx,W*.75,H*.82,20,'#26323f'); label(ctx,W*.75,H*.82-2,'poc 保留','#c6d2e0',10);
+  node(ctx,W*.40,H*.82,20,'#1d4a39'); label(ctx,W*.40,H*.82-2,'poc 成長','#5ad1a5',10);
+  // edges
+  // edges from owner
+  arrow(ctx,W*.5,H*.12+26, W*.22,H*.42-22,'#d2a8ff', [4,4]);
+  arrow(ctx,W*.5,H*.12+26, W*.60,H*.42-22,'#d2a8ff');
+  arrow(ctx,W*.5,H*.12+26, W*.85,H*.42-22,'#d2a8ff', [4,4]);
+  // labels along edges
+  label(ctx,W*.30,H*.28,'grew_to','#5ad1a5',9,'left');
+  label(ctx,W*.66,H*.28,'aborted_to','#ff6b6b',9,'left');
+  label(ctx,W*.12,H*.28,'proposed_from','#d2a8ff',9,'left');
+  // child edges (grew_to)
+  arrow(ctx,W*.60+22,H*.42+10, W*.40-20,H*.82,'#5ad1a5');
+  arrow(ctx,W*.85-22,H*.42+10, W*.75+20,H*.82,'#3a4858', [4,4]);
+  // right column legend text
+  label(ctx,W*.86,H*.5,'保留 (pending)','#8b9bb0',10,'left');
+  label(ctx,W*.86,H*.62,'実行中 (running)','#ffb454',10,'left');
+  label(ctx,W*.86,H*.74,'成長中 (growing)','#5ad1a5',10,'left');
+  label(ctx,W*.86,H*.86,'撤退 (aborted)','#ff6b6b',10,'left');
+  label(ctx,W*.86,H*.98,'owner=黒 crown','#d2a8ff',9,'left');
+})();
+// ---------- v3.2 team hierarchy ----------
+(function(){
+  const c=document.getElementById('cnvTeam'); if(!c) return;
+  const ctx=fitCanvas(c);
+  const W=c.clientWidth, H=parseInt(c.style.height);
+  // Owner at top center
+  box(ctx,W*.5-90,20,180,44,'#0c1626'); label(ctx,W*.5,42,'owner 👑 (graph editor)','#d2a8ff',12);
+  arrow(ctx,W*.5,64, W*.5,100,'#9fb3c8');
+  // Team container box
+  box(ctx,W*.5-340,100,680,250,'#0f141b','#3a4858');
+  label(ctx,W*.5,116,'Team: scout (1ノード, 編成単位)','#6aa9ff',12,'center');
+  // 3 stages inside
+  const stages=[
+    {label:'planner',desc:'計画分解',x:W*.5-220,color:'#5ad1a5'},
+    {label:'executer',desc:'実行',x:W*.5,color:'#ffb454'},
+    {label:'accepter',desc:'受け入れ judge',x:W*.5+220,color:'#d2a8ff'},
+  ];
+  stages.forEach((s,i)=>{
+    box(ctx,s.x-70,150,140,60,'#1a1f2a');
+    label(ctx,s.x,170,s.label,s.color,13);
+    label(ctx,s.x,190,s.desc,'#8b9bb0',10);
+  });
+  // plan → exec → accept arrows
+  arrow(ctx,W*.5-220+70,180, W*.5-70,180,'#5ad1a5');
+  arrow(ctx,W*.5+70,180, W*.5+220-70,180,'#ffb454');
+  label(ctx,W*.5-145,172,'makes_plan','#5ad1a5',9);
+  label(ctx,W*.5+100,172,'executes','#ffb454',9);
+  // reject loop
+  ctx.strokeStyle='#f85149'; ctx.lineWidth=1.6; ctx.setLineDash([5,4]);
+  ctx.beginPath();
+  ctx.moveTo(W*.5+220,210);
+  ctx.bezierCurveTo(W*.5+260,260, W*.5-180,260, W*.5-220,210);
+  ctx.stroke(); ctx.setLineDash([]);
+  arrow(ctx,W*.5-220,212, W*.5-220,210,'#f85149');  // arrowhead pointing up
+  label(ctx,W*.5,255,'reject → revision_target','#ff6b6b',10);
+  // accept to owner (up arrow on side)
+  ctx.strokeStyle='#5ad1a5'; ctx.lineWidth=1.6;
+  ctx.beginPath();
+  ctx.moveTo(W*.5+220,150);
+  ctx.bezierCurveTo(W*.5+380,120, W*.5+380,40, W*.5+90,42);
+  ctx.stroke();
+  arrow(ctx,W*.5+95,42, W*.5+90,42,'#5ad1a5');
+  label(ctx,W*.5+340,70,'accept → owner','#5ad1a5',10);
+  // legend
+  label(ctx,W*.5,H-10,'owner=graph editor / Team=編成単位 / stage=社内工程','#5a6b80',10);
+})();
+// ---------- 05 tick loop ----------
+(function(){
+  const c=document.getElementById('cnvTick'); const ctx=fitCanvas(c);
+  const W=c.clientWidth, H=parseInt(c.style.height);
+  const steps=[
+    "保留ノード選択",
+    "実行中に更新",
+    "ロール毎の\nプロンプト構築",
+    "execute_task\n(共通 executor)",
+    "verdict JSON 解析",
+    "育成 / 撤退 +\n子ノード生成",
+    "agent_runs++\n(予算チェック)",
+  ];
+  const r=24, gap=(W-200)/(steps.length-1), y=H*.32;
+  ctx.strokeStyle='#6aa9ff'; ctx.lineWidth=2;
+  // loop back arc
+  ctx.beginPath(); ctx.moveTo(W-100,y); ctx.bezierCurveTo(W+20,y, W+20,H*.8, W-100,H*.8);
+  ctx.setLineDash([5,5]); ctx.stroke(); ctx.setLineDash([]);
+  arrow(ctx,W-100,H*.8, W-120,H*.8,'#6aa9ff');
+  label(ctx,W-40,H*.56,'次tick','#6aa9ff',10);
+  steps.forEach((s,i)=>{
+    const x=100+i*gap;
+    node(ctx,x,y,r, i===0?'#1d4a39': i===3?'#1a1308':'#0c1626');
+    label(ctx,x,y-1, '0'+(i+1),'#c6d2e0',10);
+    arrow(ctx,x+r,y, x+gap-r,y,'#9fb3c8');
+    // caption
+    const lines=s.split('\n'); lines.forEach((ln,j)=>{
+      label(ctx,x,y+r+16+j*14,ln,'#9fb3c8',10);
+    });
+  });
+  // budget guard
+  box(ctx,W*.5-160,H-54,320,34,'#2a0f0f');
+  label(ctx,W*.5,H-37,'agent_runs ≥ max_agent_runs で terminated','#ff6b6b',11);
+  arrow(ctx,W*.82,y+r+34, W*.82,H-20,'#4e1f1f', [3,3]);
+})();
+</script>
+</body>
+</html>

--- a/skills/kage/SKILL.md
+++ b/skills/kage/SKILL.md
@@ -21,6 +21,7 @@ description: Autonomous AI Project Agent & Cron Task Runner. Orchestrates repeti
 
 ## CLI
 
+- `kage quest new <name> --direction "..."` — Create a new event-driven quest. A quest dispatches a team of role agents (scout → poc → strategist) as a mind-map graph, one node per cron tick, with a `--max-agent-runs` runaway budget. `kage cron run` advances active quests automatically; `kage quest list/show/stop/resume/abort-node` manage them. Quest state lives in SQLite (`quests`, `quest_nodes`, `quest_edges`), not `.kage/tasks/`. Runs flow through the normal executor, so `kage runs` / `kage logs` show quest work too.
 - `kage onboard` — Setup global directories and `kage cron`.
 - `kage init` — Initialize in current directory.
 - `kage run <task>` — Execute a specific task immediately; add `--force` to bypass suspension.

--- a/src/kage/db.py
+++ b/src/kage/db.py
@@ -64,6 +64,7 @@ def init_db():
         except sqlite3.OperationalError:
             pass
 
+    _ensure_quest_tables(cursor)
     _ensure_agent_immutable_triggers(cursor)
 
     conn.commit()
@@ -91,6 +92,74 @@ def _ensure_agent_immutable_triggers(cursor: sqlite3.Cursor) -> None:
         BEGIN
             SELECT RAISE(ABORT, 'agent_name rows are immutable');
         END
+        """
+    )
+
+
+def _ensure_quest_tables(cursor: sqlite3.Cursor) -> None:
+    """Create the quest lifecycle tables if they do not exist.
+
+    The quest lifecycle is an event-driven, team-based alternative to the cron
+    lifecycle. Tables store quests, their mind-map nodes, and directed edges.
+    """
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS quests (
+            id TEXT PRIMARY KEY,
+            project_path TEXT NOT NULL,
+            name TEXT NOT NULL,
+            direction TEXT NOT NULL,
+            status TEXT NOT NULL,
+            max_agent_runs INTEGER NOT NULL DEFAULT 50,
+            agent_runs INTEGER NOT NULL DEFAULT 0,
+            roles_json TEXT,
+            provider TEXT,
+            mode TEXT NOT NULL DEFAULT 'team',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    # Add the `mode` column to quests created before v2.
+    try:
+        cursor.execute(
+            "ALTER TABLE quests ADD COLUMN mode TEXT NOT NULL DEFAULT 'team'"
+        )
+    except sqlite3.OperationalError:
+        pass
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS quest_nodes (
+            id TEXT PRIMARY KEY,
+            quest_id TEXT NOT NULL,
+            parent_id TEXT,
+            role TEXT NOT NULL,
+            hypothesis TEXT NOT NULL,
+            status TEXT NOT NULL,
+            verdict TEXT,
+            evidence TEXT,
+            proposed_by TEXT,
+            run_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    # Add the `proposed_by` column to legacy quest_nodes tables (v1 — missing column).
+    try:
+        cursor.execute("ALTER TABLE quest_nodes ADD COLUMN proposed_by TEXT")
+    except sqlite3.OperationalError:
+        pass
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS quest_edges (
+            id TEXT PRIMARY KEY,
+            quest_id TEXT NOT NULL,
+            from_node TEXT,
+            to_node TEXT,
+            relation TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
         """
     )
 

--- a/src/kage/main.py
+++ b/src/kage/main.py
@@ -74,6 +74,11 @@ app.add_typer(connector_app, name="connector")
 migrate_app = typer.Typer(help="Run install/data migrations")
 app.add_typer(migrate_app, name="migrate")
 
+quest_app = typer.Typer(
+    help="Manage quests: event-driven, team-based mind-map lifecycles that run alongside cron tasks"
+)
+app.add_typer(quest_app, name="quest")
+
 runs_app = typer.Typer(
     help="View and manage execution runs",
     invoke_without_command=True,
@@ -1169,8 +1174,198 @@ def cron_run():
     run_all_scheduled_tasks()
 
 
+@quest_app.command("new")
+def quest_new(
+    name: str = typer.Argument(..., help="Short quest name"),
+    direction: str = typer.Option(
+        ..., "--direction", "-d", help="Vague direction / goal"
+    ),
+    project: Optional[str] = typer.Option(
+        None, "--project", "-p", help="Project path (defaults to current dir)"
+    ),
+    roles: str = typer.Option(
+        "scout,poc,strategist", "--roles", help="Comma-separated role names"
+    ),
+    max_agent_runs: int = typer.Option(
+        50, "--max-agent-runs", help="Hard cap on total agent dispatches"
+    ),
+    provider: Optional[str] = typer.Option(
+        None, "--provider", help="AI provider override (e.g. claude, gemini)"
+    ),
+    solo: bool = typer.Option(
+        False,
+        "--solo",
+        help="Legacy mode: roles spawn children directly without an owner gate",
+    ),
+):
+    """Create a new quest with a root scout node ready to dispatch."""
+    from .quest import QuestMode, create_quest, get_quest
+
+    project_path = Path(project).resolve() if project else Path.cwd().resolve()
+    quest = create_quest(
+        str(project_path),
+        name,
+        direction,
+        roles=[r.strip() for r in roles.split(",") if r.strip()],
+        max_agent_runs=max_agent_runs,
+        provider=provider,
+        mode=QuestMode.SOLO if solo else QuestMode.TEAM,
+    )
+    refreshed = get_quest(quest.id)
+    assert refreshed is not None
+    typer.echo(
+        f"Created quest {refreshed.id}: {refreshed.name} "
+        f"(status={refreshed.status}, max_agent_runs={refreshed.max_agent_runs})"
+    )
+
+
+@quest_app.command("list")
+def quest_list(
+    status_filter: Optional[str] = typer.Option(
+        None, "--status", help="Filter by quest status"
+    ),
+    project: Optional[str] = typer.Option(
+        None, "--project", "-p", help="Project path substring filter"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print structured JSON"),
+):
+    """List quests and their progress."""
+    from .quest import list_quests, node_counts
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    quests = list_quests(status_filter=status_filter, project_filter=project)
+    if json_output:
+        payload = [q.to_dict() | {"node_counts": node_counts(q.id)} for q in quests]
+        typer.echo(json.dumps(payload, ensure_ascii=False, indent=2))
+        return
+    if not quests:
+        console.print("[yellow]No quests found.[/yellow]")
+        return
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("ID", style="bold")
+    table.add_column("Name")
+    table.add_column("Status")
+    table.add_column("Runs", justify="right")
+    table.add_column("Nodes")
+    table.add_column("Direction")
+    for q in quests:
+        counts = node_counts(q.id)
+        node_summary = (
+            f"{counts.get('total', 0)} "
+            f"(exp {counts.get('explored', 0)}/grow {counts.get('growing', 0)}/"
+            f"abort {counts.get('aborted', 0)})"
+        )
+        table.add_row(
+            q.id,
+            q.name,
+            q.status,
+            f"{q.agent_runs}/{q.max_agent_runs}",
+            node_summary,
+            q.direction[:60],
+        )
+    console.print(table)
+
+
+@quest_app.command("show")
+def quest_show(
+    quest_id: str = typer.Argument(..., help="Quest ID"),
+    json_output: bool = typer.Option(False, "--json", help="Print structured JSON"),
+):
+    """Show a quest, its nodes, and edges."""
+    from .quest import get_quest, list_edges, list_nodes
+
+    quest = get_quest(quest_id)
+    if not quest:
+        typer.echo(f"Quest not found: {quest_id}")
+        raise typer.Exit(1)
+    nodes = list_nodes(quest_id)
+    edges = list_edges(quest_id)
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "quest": quest.to_dict(),
+                    "nodes": [n.to_dict() for n in nodes],
+                    "edges": [e.__dict__ for e in edges],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    console.print(
+        f"[bold cyan]{quest.id}[/bold cyan] {quest.name} (status={quest.status}, "
+        f"runs={quest.agent_runs}/{quest.max_agent_runs})"
+    )
+    console.print(f"Direction: {quest.direction}")
+    table = Table(show_header=True, header_style="bold", title="Nodes")
+    table.add_column("ID")
+    table.add_column("Role")
+    table.add_column("Status")
+    table.add_column("Verdict")
+    table.add_column("Hypothesis")
+    for n in nodes:
+        table.add_row(n.id, n.role, n.status, n.verdict or "-", n.hypothesis[:80])
+    console.print(table)
+    if edges:
+        edge_table = Table(show_header=True, header_style="bold", title="Edges")
+        edge_table.add_column("From")
+        edge_table.add_column("To")
+        edge_table.add_column("Relation")
+        for e in edges:
+            edge_table.add_row(e.from_node or "-", e.to_node or "-", e.relation)
+        console.print(edge_table)
+
+
+@quest_app.command("stop")
+def quest_stop(
+    quest_id: str = typer.Argument(..., help="Quest ID"),
+):
+    """Stop an active quest (ticks will skip it until resumed)."""
+    from .quest import get_quest, set_quest_status
+
+    if not get_quest(quest_id):
+        typer.echo(f"Quest not found: {quest_id}")
+        raise typer.Exit(1)
+    set_quest_status(quest_id, "stopped")
+    typer.echo(f"Stopped quest {quest_id}")
+
+
+@quest_app.command("resume")
+def quest_resume(
+    quest_id: str = typer.Argument(..., help="Quest ID"),
+):
+    """Resume a stopped quest."""
+    from .quest import get_quest, set_quest_status
+
+    if not get_quest(quest_id):
+        typer.echo(f"Quest not found: {quest_id}")
+        raise typer.Exit(1)
+    set_quest_status(quest_id, "active")
+    typer.echo(f"Resumed quest {quest_id}")
+
+
+@quest_app.command("abort-node")
+def quest_abort_node(
+    node_id: str = typer.Argument(..., help="Quest node ID"),
+):
+    """Force-abort a single quest node."""
+    from .quest import abort_node
+
+    node = abort_node(node_id)
+    if not node:
+        typer.echo(f"Node not found: {node_id}")
+        raise typer.Exit(1)
+    typer.echo(f"Aborted node {node_id}")
+
+
 def _is_ja() -> bool:
-    """LANG 環境変値が ja* で始まっていれば True。"""
     import os
 
     for key in ("LC_ALL", "LANG", "LANGUAGE"):

--- a/src/kage/quest.py
+++ b/src/kage/quest.py
@@ -1,0 +1,1219 @@
+"""Quest lifecycle: an event-driven, team-based alternative to the cron lifecycle.
+
+A quest is a long-running, mind-map style exploration owned by a team of role
+agents (scout, poc, strategist). The existing 1-minute `kage cron run` tick
+calls :func:`tick` once per tick; tick dispatches at most one pending node per
+active quest by materializing a role-specific prompt and reusing the normal
+executor (so runs/logs/history stay uniform).
+
+Runaway protection is provided by a per-quest ``max_agent_runs`` budget.
+
+v2 — Owner-gated team model
+---------------------------
+By default (:data:`QuestMode.TEAM`) the quest owns a mandatory ``owner`` role.
+Only the owner is allowed to mutate the task graph; scout/poc/strategist merely
+execute and emit **proposed** nodes. The tick defers owner dispatch until
+enough evidence has accumulated, forcing team-wide consensus.
+
+Pass ``--solo`` to :func:`create_quest` to fall back to the legacy "any role may
+spawn" behaviour used by v1.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from .config import KAGE_DB_PATH
+from .db import init_db
+from .parser import ExecutionMode, TaskDef
+
+QUEST_STATUS_ACTIVE = "active"
+QUEST_STATUS_DONE = "done"
+QUEST_STATUS_TERMINATED = "terminated"
+QUEST_STATUS_STOPPED = "stopped"
+
+NODE_STATUS_PENDING = "pending"
+NODE_STATUS_RUNNING = "running"
+NODE_STATUS_EXPLORED = "explored"
+NODE_STATUS_ABORTED = "aborted"
+NODE_STATUS_GROWING = "growing"
+NODE_STATUS_PROPOSED = "proposed"
+
+ROLE_SCOUT = "scout"
+ROLE_POC = "poc"
+ROLE_STRATEGIST = "strategist"
+ROLE_OWNER = "owner"
+
+_VERDICT_PROMISING = "promising"
+_VERDICT_DEAD = "dead"
+
+_DEFAULT_ROLES = [ROLE_SCOUT, ROLE_POC, ROLE_STRATEGIST, ROLE_OWNER]
+_TEAM_ROLES = [ROLE_SCOUT, ROLE_POC, ROLE_STRATEGIST]
+_DEFAULT_MAX_AGENT_RUNS = 50
+
+# Owner dispatch thresholds (team mode).
+_OWNER_MIN_PROPOSED = 1
+_OWNER_MIN_CHILDREN_COMPLETED = 1
+
+
+class QuestMode(str, Enum):
+    SOLO = "solo"
+    TEAM = "team"
+
+
+@dataclass
+class Quest:
+    id: str
+    project_path: str
+    name: str
+    direction: str
+    status: str
+    max_agent_runs: int
+    agent_runs: int
+    roles: list[str] = field(default_factory=lambda: list(_DEFAULT_ROLES))
+    provider: Optional[str] = None
+    mode: QuestMode = QuestMode.TEAM
+    created_at: str = ""
+    updated_at: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "project_path": self.project_path,
+            "name": self.name,
+            "direction": self.direction,
+            "status": self.status,
+            "max_agent_runs": self.max_agent_runs,
+            "agent_runs": self.agent_runs,
+            "roles": list(self.roles),
+            "provider": self.provider,
+            "mode": self.mode.value
+            if isinstance(self.mode, QuestMode)
+            else str(self.mode),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class QuestNode:
+    id: str
+    quest_id: str
+    parent_id: Optional[str]
+    role: str
+    hypothesis: str
+    status: str
+    verdict: Optional[str] = None
+    evidence: Optional[str] = None
+    proposed_by: Optional[str] = None
+    run_id: Optional[str] = None
+    created_at: str = ""
+    updated_at: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "quest_id": self.quest_id,
+            "parent_id": self.parent_id,
+            "role": self.role,
+            "hypothesis": self.hypothesis,
+            "status": self.status,
+            "verdict": self.verdict,
+            "evidence": self.evidence,
+            "proposed_by": self.proposed_by,
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass
+class QuestEdge:
+    id: str
+    quest_id: str
+    from_node: Optional[str]
+    to_node: Optional[str]
+    relation: str
+    created_at: str = ""
+
+
+def _now() -> str:
+    return datetime.now().astimezone().isoformat()
+
+
+def _connect() -> sqlite3.Connection:
+    init_db()
+    conn = sqlite3.connect(KAGE_DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _row_to_quest(row: sqlite3.Row) -> Quest:
+    roles: list[str] = _DEFAULT_ROLES
+    raw_roles = row["roles_json"]
+    if raw_roles:
+        try:
+            parsed = json.loads(raw_roles)
+            if isinstance(parsed, list):
+                roles = [str(r) for r in parsed] or list(_DEFAULT_ROLES)
+        except json.JSONDecodeError:
+            pass
+    return Quest(
+        id=row["id"],
+        project_path=row["project_path"],
+        name=row["name"],
+        direction=row["direction"],
+        status=row["status"],
+        max_agent_runs=row["max_agent_runs"],
+        agent_runs=row["agent_runs"],
+        roles=roles,
+        provider=row["provider"],
+        mode=QuestMode(row["mode"])
+        if "mode" in row.keys() and row["mode"]
+        else QuestMode.TEAM,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_node(row: sqlite3.Row) -> QuestNode:
+    return QuestNode(
+        id=row["id"],
+        quest_id=row["quest_id"],
+        parent_id=row["parent_id"],
+        role=row["role"],
+        hypothesis=row["hypothesis"],
+        status=row["status"],
+        verdict=row["verdict"],
+        evidence=row["evidence"],
+        proposed_by=row["proposed_by"] if "proposed_by" in row.keys() else None,
+        run_id=row["run_id"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _row_to_edge(row: sqlite3.Row) -> QuestEdge:
+    return QuestEdge(
+        id=row["id"],
+        quest_id=row["quest_id"],
+        from_node=row["from_node"],
+        to_node=row["to_node"],
+        relation=row["relation"],
+        created_at=row["created_at"],
+    )
+
+
+def create_quest(
+    project_path: str,
+    name: str,
+    direction: str,
+    *,
+    roles: Optional[list[str]] = None,
+    max_agent_runs: int = _DEFAULT_MAX_AGENT_RUNS,
+    provider: Optional[str] = None,
+    initial_role: Optional[str] = None,
+    mode: QuestMode = QuestMode.TEAM,
+) -> Quest:
+    """Create a new quest with a single root node ready to dispatch.
+
+    In team mode (default) the initial role is ``owner``; the owner will decide
+    the first scout/poc to actually run. In ``--solo`` mode the root node is a
+    scout that dispatches immediately (legacy v1 behaviour).
+    """
+    if mode == QuestMode.TEAM:
+        roles = list(roles or _DEFAULT_ROLES)
+        if ROLE_OWNER not in roles:
+            roles.append(ROLE_OWNER)
+        if initial_role is None:
+            initial_role = ROLE_OWNER
+    else:
+        roles = list(roles or _TEAM_ROLES)
+        if initial_role is None:
+            initial_role = ROLE_SCOUT
+    quest_id = uuid.uuid4().hex[:12]
+    now = _now()
+    conn = _connect()
+    try:
+        conn.execute(
+            """
+            INSERT INTO quests
+                (id, project_path, name, direction, status, max_agent_runs,
+                 agent_runs, roles_json, provider, mode, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                quest_id,
+                str(project_path),
+                name,
+                direction,
+                QUEST_STATUS_ACTIVE,
+                max_agent_runs,
+                0,
+                json.dumps(roles, ensure_ascii=False),
+                provider,
+                mode.value,
+                now,
+                now,
+            ),
+        )
+        root = QuestNode(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest_id,
+            parent_id=None,
+            role=initial_role,
+            hypothesis=direction,
+            status=NODE_STATUS_PENDING,
+            created_at=now,
+            updated_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_nodes
+                (id, quest_id, parent_id, role, hypothesis, status,
+                 verdict, evidence, proposed_by, run_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)
+            """,
+            (
+                root.id,
+                root.quest_id,
+                root.parent_id,
+                root.role,
+                root.hypothesis,
+                root.status,
+                root.created_at,
+                root.updated_at,
+            ),
+        )
+        conn.commit()
+        quest = get_quest(quest_id)
+        assert quest is not None
+        return quest
+    finally:
+        conn.close()
+
+
+def get_quest(quest_id: str) -> Optional[Quest]:
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT * FROM quests WHERE id = ?",
+            (quest_id,),
+        ).fetchone()
+        return _row_to_quest(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_quests(
+    *,
+    status_filter: Optional[str] = None,
+    project_filter: Optional[str] = None,
+) -> list[Quest]:
+    conn = _connect()
+    try:
+        query = "SELECT * FROM quests"
+        clauses: list[str] = []
+        params: list[object] = []
+        if status_filter:
+            clauses.append("status = ?")
+            params.append(status_filter)
+        if project_filter:
+            clauses.append("project_path LIKE ?")
+            params.append(f"%{project_filter}%")
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        query += " ORDER BY created_at DESC"
+        rows = conn.execute(query, params).fetchall()
+        return [_row_to_quest(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def set_quest_status(quest_id: str, status: str) -> None:
+    conn = _connect()
+    try:
+        conn.execute(
+            "UPDATE quests SET status = ?, updated_at = ? WHERE id = ?",
+            (status, _now(), quest_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def list_nodes(quest_id: str) -> list[QuestNode]:
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM quest_nodes WHERE quest_id = ? ORDER BY created_at ASC",
+            (quest_id,),
+        ).fetchall()
+        return [_row_to_node(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_node(node_id: str) -> Optional[QuestNode]:
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT * FROM quest_nodes WHERE id = ?",
+            (node_id,),
+        ).fetchone()
+        return _row_to_node(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_edges(quest_id: str) -> list[QuestEdge]:
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM quest_edges WHERE quest_id = ? ORDER BY created_at ASC",
+            (quest_id,),
+        ).fetchall()
+        return [_row_to_edge(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def abort_node(node_id: str) -> Optional[QuestNode]:
+    conn = _connect()
+    try:
+        now = _now()
+        conn.execute(
+            "UPDATE quest_nodes SET status = ?, updated_at = ? WHERE id = ?",
+            (NODE_STATUS_ABORTED, now, node_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return get_node(node_id)
+
+
+def node_counts(quest_id: str) -> dict[str, int]:
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS c FROM quest_nodes WHERE quest_id = ? "
+            "GROUP BY status",
+            (quest_id,),
+        ).fetchall()
+        counts = {row["status"]: row["c"] for row in rows}
+        counts["total"] = sum(counts.values())
+        return counts
+    finally:
+        conn.close()
+
+
+def _role_prompt(
+    role: str,
+    quest: Quest,
+    node: QuestNode,
+    ancestor_evidence: str,
+    proposed_summary: str = "",
+    completed_summary: str = "",
+) -> str:
+    direction = quest.direction
+    hypothesis = node.hypothesis
+    ancestry = ancestor_evidence or "(no prior evidence yet)"
+
+    if role == ROLE_OWNER:
+        proposed_text = proposed_summary or "(none)"
+        completed_text = completed_summary or "(none)"
+        body = (
+            "# Role: Owner (Quest Director)\n"
+            f"## Quest direction\n{direction}\n\n"
+            "## Recent completed work\n"
+            f"{completed_text}\n\n"
+            "## Pending proposed nodes awaiting your decision\n"
+            f"{proposed_text}\n\n"
+            "You are the ONLY agent that may create, update, or abort task "
+            "nodes. Do NOT run experiments yourself. Review the evidence from "
+            "scout/poc/strategist and only then decide which proposals to "
+            "promote into pending work, which to abort, which new roles to "
+            "spawn, or whether to finish. Consensus matters: do not act on a "
+            "single source — wait until at least two pieces of evidence "
+            "corroborate before promoting."
+        )
+        owner_suffix = (
+            "\n\n## Output contract\n"
+            "End your response with a fenced JSON block of exactly this "
+            "shape and nothing after it:\n"
+            "```json\n"
+            '{"evidence": "<short synthesis>", "finish": false, '
+            '"actions": [\n'
+            '  {"type": "promote", "node_id": "<id>"},\n'
+            '  {"type": "abort",   "node_id": "<id>"},\n'
+            '  {"type": "spawn",   "role": "scout|poc|strategist|owner", '
+            '"direction": "<hypothesis>"},\n'
+            '  {"type": "finish",  "reason": "..."}\n'
+            "]}\n"
+            "```\n"
+            "`actions` may be empty. Set `finish: true` once the quest is "
+            "closed. `spawn` with `role: owner` schedules another owner "
+            "round later."
+        )
+        return body + owner_suffix
+
+    common_suffix = (
+        "\n\n## Output contract\n"
+        "End your response with a fenced JSON block of exactly this shape and "
+        "nothing after it:\n"
+        "```json\n"
+        '{"verdict": "promising" | "dead", "evidence": "<short summary>", '
+        '"new_directions": ["<hypothesis>", ...]}\n'
+        "```\n"
+        "`verdict` must be one of the two literals. `new_directions` may be empty."
+    )
+
+    if role == ROLE_SCOUT:
+        body = (
+            "# Role: Scout\n"
+            f"## Quest direction\n{direction}\n\n"
+            f"## Hypothesis to investigate\n{hypothesis}\n\n"
+            f"## Prior evidence\n{ancestry}\n\n"
+            "Investigate the current state of the repository / environment. "
+            "Look for what already exists, what is missing, and what is worth "
+            "trying. Propose concrete, falsifiable candidate hypotheses to test "
+            "next as PoCs."
+        )
+    elif role == ROLE_POC:
+        body = (
+            "# Role: PoC\n"
+            f"## Quest direction\n{direction}\n\n"
+            f"## Hypothesis to test\n{hypothesis}\n\n"
+            f"## Prior evidence\n{ancestry}\n\n"
+            "Run the smallest possible proof of concept for this hypothesis "
+            "inside the working directory. Prefer throwaway scripts and quick "
+            "measurements over polish. If it works, say what to grow next; if "
+            "it fails, say exactly why and whether anything salvageable remains."
+        )
+    else:  # strategist
+        body = (
+            "# Role: Strategist\n"
+            f"## Quest direction\n{direction}\n\n"
+            f"## Prior evidence\n{ancestry}\n\n"
+            "Evaluate the accumulated evidence like a ROI assessment. Decide "
+            "whether the quest should keep going, which direction to double down "
+            "on, and whether to close the quest. If the direction is exhausted, "
+            "set verdict to 'dead' and leave new_directions empty."
+        )
+    return body + common_suffix
+
+
+def _ancestor_evidence(quest_id: str, node: QuestNode) -> str:
+    """Collect evidence walking up the parent chain of a node."""
+    conn = _connect()
+    try:
+        parts: list[str] = []
+        current_id = node.parent_id
+        seen: set[str] = set()
+        while current_id and current_id not in seen:
+            seen.add(current_id)
+            row = conn.execute(
+                "SELECT role, hypothesis, verdict, evidence, parent_id "
+                "FROM quest_nodes WHERE id = ?",
+                (current_id,),
+            ).fetchone()
+            if not row:
+                break
+            verdict = row["verdict"] or "-"
+            evidence = row["evidence"] or "-"
+            parts.append(
+                f"- [{row['role']}] {row['hypothesis']} (verdict={verdict}): {evidence}"
+            )
+            current_id = row["parent_id"]
+        return "\n".join(parts) if parts else ""
+    finally:
+        conn.close()
+
+
+def _proposed_summary(quest_id: str) -> str:
+    """List current proposed nodes for the owner's triage queue."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT id, role, hypothesis, proposed_by "
+            "FROM quest_nodes WHERE quest_id = ? AND status = ? "
+            "ORDER BY created_at ASC",
+            (quest_id, NODE_STATUS_PROPOSED),
+        ).fetchall()
+        if not rows:
+            return "(no pending proposed nodes)"
+        lines = [
+            f"- [{r['role']}] {r['id']} (by {r['proposed_by'] or '-'}) "
+            f"{r['hypothesis']}"
+            for r in rows
+        ]
+        return "\n".join(lines)
+    finally:
+        conn.close()
+
+
+def _completed_summary(quest_id: str, limit: int = 10) -> str:
+    """Latest completed (explored/growing/aborted) nodes for the owner."""
+    conn = _connect()
+    try:
+        rows = conn.execute(
+            "SELECT id, role, hypothesis, verdict, evidence "
+            "FROM quest_nodes WHERE quest_id = ? "
+            "AND status IN (?, ?, ?) "
+            "ORDER BY updated_at DESC LIMIT ?",
+            (
+                quest_id,
+                NODE_STATUS_EXPLORED,
+                NODE_STATUS_GROWING,
+                NODE_STATUS_ABORTED,
+                limit,
+            ),
+        ).fetchall()
+        if not rows:
+            return "(no completed work yet)"
+        lines = [
+            f"- [{r['role']}] {r['id']} verdict={r['verdict'] or '-'} · "
+            f"{r['hypothesis']} :: {r['evidence'] or '-'}"
+            for r in rows
+        ]
+        return "\n".join(lines)
+    finally:
+        conn.close()
+
+
+def _synthesize_task(quest: Quest, node: QuestNode, prompt: str) -> TaskDef:
+    return TaskDef(
+        name=f"quest:{quest.id}:{node.id}",
+        cron="* * * * *",
+        active=True,
+        mode=ExecutionMode.CONTINUOUS,
+        prompt=prompt,
+        provider=quest.provider,
+        working_dir=str(quest.project_path),
+    )
+
+
+_VERDICT_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def _parse_verdict(stdout: str) -> Optional[dict]:
+    if not stdout:
+        return None
+    matches = list(_VERDICT_BLOCK_RE.finditer(stdout))
+    for match in reversed(matches):
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and "verdict" in payload:
+            return payload
+    return None
+
+
+def _record_node_outcome(
+    conn: sqlite3.Connection,
+    node: QuestNode,
+    *,
+    status: str,
+    verdict: Optional[str],
+    evidence: Optional[str],
+    run_id: Optional[str],
+) -> None:
+    now = _now()
+    conn.execute(
+        """
+        UPDATE quest_nodes
+        SET status = ?, verdict = ?, evidence = ?, run_id = ?, updated_at = ?
+        WHERE id = ?
+        """,
+        (status, verdict, evidence, run_id, now, node.id),
+    )
+
+
+def _spawn_children(
+    conn: sqlite3.Connection,
+    quest: Quest,
+    parent_node: QuestNode,
+    new_directions: list[str],
+    *,
+    role: str,
+    relation: str,
+    as_proposed: bool = False,
+) -> list[QuestNode]:
+    """Create child nodes (or proposed candidates in team mode) of ``parent_node``.
+
+    ``as_proposed=True`` inserts the rows in :data:`NODE_STATUS_PROPOSED` with a
+    ``proposed_from`` edge so the owner can later promote/abort them. In team
+    mode non-owner roles must always pass ``as_proposed=True``.
+    """
+    now = _now()
+    created: list[QuestNode] = []
+    initial_status = NODE_STATUS_PROPOSED if as_proposed else NODE_STATUS_PENDING
+    for direction in new_directions:
+        direction = (direction or "").strip()
+        if not direction:
+            continue
+        child = QuestNode(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest.id,
+            parent_id=parent_node.id,
+            role=role,
+            hypothesis=direction,
+            status=initial_status,
+            proposed_by=parent_node.role if as_proposed else None,
+            created_at=now,
+            updated_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_nodes
+                (id, quest_id, parent_id, role, hypothesis, status,
+                 verdict, evidence, proposed_by, run_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?)
+            """,
+            (
+                child.id,
+                child.quest_id,
+                child.parent_id,
+                child.role,
+                child.hypothesis,
+                child.status,
+                child.proposed_by,
+                child.created_at,
+                child.updated_at,
+            ),
+        )
+        edge = QuestEdge(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest.id,
+            from_node=parent_node.id,
+            to_node=child.id,
+            relation=relation,
+            created_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_edges
+                (id, quest_id, from_node, to_node, relation, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                edge.id,
+                edge.quest_id,
+                edge.from_node,
+                edge.to_node,
+                edge.relation,
+                edge.created_at,
+            ),
+        )
+        created.append(child)
+    return created
+
+
+def _has_pending_strategist(conn: sqlite3.Connection, quest_id: str) -> bool:
+    row = conn.execute(
+        "SELECT COUNT(*) AS c FROM quest_nodes WHERE quest_id = ? "
+        "AND role = ? AND status = ?",
+        (quest_id, ROLE_STRATEGIST, NODE_STATUS_PENDING),
+    ).fetchone()
+    return bool(row and row["c"] > 0)
+
+
+def _select_pending_node(
+    conn: sqlite3.Connection, quest_id: str, quest: Quest
+) -> Optional[QuestNode]:
+    """Pick the next dispatchable node.
+
+    In team mode the only ``pending`` node we *should* see is the owner when
+    enough evidence has accumulated; non-owner runs go via proposed nodes that
+    require owner ``promote`` action first. ``_should_dispatch_owner`` is the
+    gate. In solo mode every pending node is fair game.
+    """
+    row = conn.execute(
+        "SELECT * FROM quest_nodes WHERE quest_id = ? AND status = ? "
+        "ORDER BY created_at ASC LIMIT 1",
+        (quest_id, NODE_STATUS_PENDING),
+    ).fetchone()
+    if row is None:
+        return None
+    node = _row_to_node(row)
+    if quest.mode == QuestMode.TEAM and node.role == ROLE_OWNER:
+        if not _should_dispatch_owner(conn, quest_id):
+            return None
+    return node
+
+
+def _should_dispatch_owner(conn: sqlite3.Connection, quest_id: str) -> bool:
+    """Gate the owner's evaluation until enough evidence has accumulated."""
+    proposed = conn.execute(
+        "SELECT COUNT(*) AS c FROM quest_nodes WHERE quest_id = ? AND status = ?",
+        (quest_id, NODE_STATUS_PROPOSED),
+    ).fetchone()
+    completed = conn.execute(
+        "SELECT COUNT(*) AS c FROM quest_nodes WHERE quest_id = ? "
+        "AND status IN (?, ?, ?)",
+        (
+            quest_id,
+            NODE_STATUS_EXPLORED,
+            NODE_STATUS_GROWING,
+            NODE_STATUS_ABORTED,
+        ),
+    ).fetchone()
+    pending = conn.execute(
+        "SELECT COUNT(*) AS c FROM quest_nodes WHERE quest_id = ? AND status = ?",
+        (quest_id, NODE_STATUS_PENDING),
+    ).fetchone()
+    proposed_n = proposed["c"] if proposed else 0
+    completed_n = completed["c"] if completed else 0
+    pending_n = pending["c"] if pending else 0
+    if proposed_n >= _OWNER_MIN_PROPOSED:
+        return True
+    if completed_n >= _OWNER_MIN_CHILDREN_COMPLETED:
+        return True
+    if proposed_n == 0 and completed_n == 0 and pending_n <= 1:
+        return True
+    return False
+
+
+def _mark_running(conn: sqlite3.Connection, node: QuestNode) -> None:
+    now = _now()
+    conn.execute(
+        "UPDATE quest_nodes SET status = ?, updated_at = ? WHERE id = ?",
+        (NODE_STATUS_RUNNING, now, node.id),
+    )
+
+
+def _increment_agent_runs(
+    conn: sqlite3.Connection, quest_id: str, quest: Quest
+) -> None:
+    now = _now()
+    new_count = quest.agent_runs + 1
+    conn.execute(
+        "UPDATE quests SET agent_runs = ?, updated_at = ? WHERE id = ?",
+        (new_count, now, quest_id),
+    )
+
+
+def _apply_outcome(
+    conn: sqlite3.Connection,
+    quest: Quest,
+    node: QuestNode,
+    stdout: str,
+    run_id: Optional[str],
+) -> None:
+    if quest.mode == QuestMode.TEAM and node.role == ROLE_OWNER:
+        _apply_owner_outcome(conn, quest, node, stdout, run_id)
+        return
+
+    verdict_payload = _parse_verdict(stdout)
+    verdict_str: Optional[str] = None
+    evidence: Optional[str] = None
+    new_directions: list[str] = []
+
+    if verdict_payload:
+        verdict_str = str(verdict_payload.get("verdict", "")).strip().lower()
+        evidence = str(verdict_payload.get("evidence", "")).strip() or None
+        raw_dirs = verdict_payload.get("new_directions")
+        if isinstance(raw_dirs, list):
+            new_directions = [str(d).strip() for d in raw_dirs if str(d).strip()]
+
+    team_mode = quest.mode == QuestMode.TEAM
+
+    if node.role == ROLE_STRATEGIST:
+        status = NODE_STATUS_EXPLORED
+        _record_node_outcome(
+            conn,
+            node,
+            status=status,
+            verdict=verdict_str,
+            evidence=evidence,
+            run_id=run_id,
+        )
+        if verdict_str == _VERDICT_DEAD:
+            conn.execute(
+                "UPDATE quests SET status = ?, updated_at = ? WHERE id = ?",
+                (QUEST_STATUS_DONE, _now(), quest.id),
+            )
+        return
+
+    if verdict_str == _VERDICT_PROMISING:
+        _record_node_outcome(
+            conn,
+            node,
+            status=NODE_STATUS_GROWING,
+            verdict=_VERDICT_PROMISING,
+            evidence=evidence,
+            run_id=run_id,
+        )
+        if new_directions:
+            _spawn_children(
+                conn,
+                quest,
+                node,
+                new_directions,
+                role=ROLE_POC,
+                relation="grew_to",
+                as_proposed=team_mode,
+            )
+    elif verdict_str == _VERDICT_DEAD:
+        _record_node_outcome(
+            conn,
+            node,
+            status=NODE_STATUS_ABORTED,
+            verdict=_VERDICT_DEAD,
+            evidence=evidence,
+            run_id=run_id,
+        )
+        if team_mode:
+            # Adding a strategy proposal for the owner to triage rather than
+            # dispatching autonomously in team mode; scout still spawns an
+            # immediate strategist in solo mode.
+            _spawn_children(
+                conn,
+                quest,
+                node,
+                [f"Assess progress on quest: {quest.direction}"],
+                role=ROLE_STRATEGIST,
+                relation="aborted_to",
+                as_proposed=True,
+            )
+        elif not _has_pending_strategist(conn, quest.id):
+            _spawn_children(
+                conn,
+                quest,
+                node,
+                [f"Assess progress on quest: {quest.direction}"],
+                role=ROLE_STRATEGIST,
+                relation="aborted_to",
+            )
+    else:
+        # No parseable verdict: keep node explored but do not branch.
+        _record_node_outcome(
+            conn,
+            node,
+            status=NODE_STATUS_EXPLORED,
+            verdict=verdict_str,
+            evidence=evidence or stdout.strip()[:500] or None,
+            run_id=run_id,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Owner outcome handling (team mode only)
+# --------------------------------------------------------------------------- #
+_ACTION_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def _parse_owner_actions(stdout: str) -> Optional[dict]:
+    if not stdout:
+        return None
+    matches = list(_ACTION_BLOCK_RE.finditer(stdout))
+    for match in reversed(matches):
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and "actions" in payload:
+            return payload
+    return None
+
+
+def _apply_owner_outcome(
+    conn: sqlite3.Connection,
+    quest: Quest,
+    node: QuestNode,
+    stdout: str,
+    run_id: Optional[str],
+) -> None:
+    payload = _parse_owner_actions(stdout)
+    evidence = None
+    actions: list[dict] = []
+    finish = False
+    if payload:
+        evidence = str(payload.get("evidence", "")).strip() or None
+        raw_actions = payload.get("actions")
+        if isinstance(raw_actions, list):
+            actions = [a for a in raw_actions if isinstance(a, dict)]
+        finish = bool(payload.get("finish", False))
+
+    _record_node_outcome(
+        conn,
+        node,
+        status=NODE_STATUS_EXPLORED,
+        verdict="owned",
+        evidence=evidence or stdout.strip()[:500] or None,
+        run_id=run_id,
+    )
+
+    if finish:
+        conn.execute(
+            "UPDATE quests SET status = ?, updated_at = ? WHERE id = ?",
+            (QUEST_STATUS_DONE, _now(), quest.id),
+        )
+        return
+
+    for action in actions:
+        _apply_owner_action(conn, quest, node, action)
+
+    # Schedule the next owner round so the quest keeps progressing until
+    # the owner eventually returns ``finish: true``.
+    _spawn_children(
+        conn,
+        quest,
+        node,
+        [f"Continue triage on quest: {quest.direction}"],
+        role=ROLE_OWNER,
+        relation="spawned",
+    )
+
+
+def _apply_owner_action(
+    conn: sqlite3.Connection, quest: Quest, owner_node: QuestNode, action: dict
+) -> None:
+    action_type = str(action.get("type", "")).strip().lower()
+    target_id = str(action.get("node_id", "") or "").strip()
+    now = _now()
+
+    if action_type == "promote":
+        if not target_id:
+            return
+        row = conn.execute(
+            "SELECT * FROM quest_nodes WHERE id = ? AND quest_id = ?",
+            (target_id, quest.id),
+        ).fetchone()
+        if not row:
+            return
+        if row["status"] != NODE_STATUS_PROPOSED:
+            # Owner can only promote proposals — silently ignore others.
+            return
+        conn.execute(
+            "UPDATE quest_nodes SET status = ?, updated_at = ? WHERE id = ?",
+            (NODE_STATUS_PENDING, now, target_id),
+        )
+        edge = QuestEdge(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest.id,
+            from_node=owner_node.id,
+            to_node=target_id,
+            relation="promoted",
+            created_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_edges
+                (id, quest_id, from_node, to_node, relation, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                edge.id,
+                edge.quest_id,
+                edge.from_node,
+                edge.to_node,
+                edge.relation,
+                edge.created_at,
+            ),
+        )
+    elif action_type == "abort":
+        if not target_id:
+            return
+        row = conn.execute(
+            "SELECT id, status FROM quest_nodes WHERE id = ? AND quest_id = ?",
+            (target_id, quest.id),
+        ).fetchone()
+        if not row:
+            return
+        conn.execute(
+            "UPDATE quest_nodes SET status = ?, updated_at = ? WHERE id = ?",
+            (NODE_STATUS_ABORTED, now, target_id),
+        )
+        edge = QuestEdge(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest.id,
+            from_node=owner_node.id,
+            to_node=target_id,
+            relation="aborted_to",
+            created_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_edges
+                (id, quest_id, from_node, to_node, relation, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                edge.id,
+                edge.quest_id,
+                edge.from_node,
+                edge.to_node,
+                edge.relation,
+                edge.created_at,
+            ),
+        )
+    elif action_type == "spawn":
+        role = str(action.get("role", "") or "").strip()
+        if role not in _DEFAULT_ROLES:
+            return
+        direction = str(action.get("direction", "") or "").strip()
+        if not direction:
+            return
+        initial_status = (
+            NODE_STATUS_PROPOSED if role != ROLE_OWNER else NODE_STATUS_PENDING
+        )
+        child = QuestNode(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest.id,
+            parent_id=owner_node.id,
+            role=role,
+            hypothesis=direction,
+            status=initial_status,
+            proposed_by=owner_node.role if role != ROLE_OWNER else None,
+            created_at=now,
+            updated_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_nodes
+                (id, quest_id, parent_id, role, hypothesis, status,
+                 verdict, evidence, proposed_by, run_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?)
+            """,
+            (
+                child.id,
+                child.quest_id,
+                child.parent_id,
+                child.role,
+                child.hypothesis,
+                child.status,
+                child.proposed_by,
+                child.created_at,
+                child.updated_at,
+            ),
+        )
+        edge = QuestEdge(
+            id=uuid.uuid4().hex[:12],
+            quest_id=quest.id,
+            from_node=owner_node.id,
+            to_node=child.id,
+            relation="spawned",
+            created_at=now,
+        )
+        conn.execute(
+            """
+            INSERT INTO quest_edges
+                (id, quest_id, from_node, to_node, relation, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                edge.id,
+                edge.quest_id,
+                edge.from_node,
+                edge.to_node,
+                edge.relation,
+                edge.created_at,
+            ),
+        )
+    elif action_type == "finish":
+        conn.execute(
+            "UPDATE quests SET status = ?, updated_at = ? WHERE id = ?",
+            (QUEST_STATUS_DONE, now, quest.id),
+        )
+
+
+def tick(dry_run: bool = False) -> list[dict]:
+    """Advance every active quest by at most one node each.
+
+    Called once per ``kage cron run`` tick. Returns a list of dispatch summaries.
+    """
+    summaries: list[dict] = []
+    quests = list_quests(status_filter=QUEST_STATUS_ACTIVE)
+    for quest in quests:
+        if quest.agent_runs >= quest.max_agent_runs:
+            set_quest_status(quest.id, QUEST_STATUS_TERMINATED)
+            summaries.append(
+                {"quest_id": quest.id, "action": "terminated", "reason": "budget"}
+            )
+            continue
+
+        conn = _connect()
+        try:
+            node = _select_pending_node(conn, quest.id, quest)
+            if node is None:
+                summaries.append({"quest_id": quest.id, "action": "idle"})
+                continue
+
+            if dry_run:
+                summaries.append(
+                    {
+                        "quest_id": quest.id,
+                        "action": "would_dispatch",
+                        "node_id": node.id,
+                        "role": node.role,
+                    }
+                )
+                continue
+
+            _mark_running(conn, node)
+            conn.commit()
+        finally:
+            conn.close()
+
+        run_id: Optional[str] = None
+        stdout = ""
+        try:
+            from .executor import execute_task
+
+            ancestor = _ancestor_evidence(quest.id, node)
+            proposed = _proposed_summary(quest.id)
+            completed = _completed_summary(quest.id)
+            prompt = _role_prompt(
+                node.role,
+                quest,
+                node,
+                ancestor,
+                proposed_summary=proposed,
+                completed_summary=completed,
+            )
+            task = _synthesize_task(quest, node, prompt)
+            result = execute_task(Path(quest.project_path), task)
+
+            if result and result.value == "started":
+                # Execute_task ran synchronously and finished; capture latest run.
+                from .runs import list_runs
+
+                recent = list_runs(limit=1, task_name=task.name)
+                if recent:
+                    run_id = recent[0].id
+                    stdout = recent[0].stdout or ""
+        except Exception as exc:  # pragma: no cover - defensive
+            stdout = f"[quest dispatch error] {exc}"
+
+        conn = _connect()
+        try:
+            # Re-load quest to refresh agent_runs.
+            refreshed = get_quest(quest.id)
+            if refreshed is None:
+                continue
+            _increment_agent_runs(conn, quest.id, refreshed)
+            fresh_node = get_node(node.id) or node
+            _apply_outcome(conn, refreshed, fresh_node, stdout, run_id)
+            conn.commit()
+            summaries.append(
+                {
+                    "quest_id": quest.id,
+                    "action": "dispatched",
+                    "node_id": node.id,
+                    "role": node.role,
+                    "run_id": run_id,
+                }
+            )
+        finally:
+            conn.close()
+    return summaries

--- a/src/kage/scheduler.py
+++ b/src/kage/scheduler.py
@@ -152,3 +152,10 @@ def run_all_scheduled_tasks():
     # invoked every minute, so a newly-enabled realtime connector will start
     # within one minute of the config change.
     manage_realtime_processes()
+
+    # Advance the event-driven quest lifecycle. Each tick dispatches at most
+    # one pending node per active quest, reusing the normal executor so quest
+    # runs appear alongside cron runs in `kage runs` / `kage logs`.
+    from .quest import tick as quest_tick
+
+    quest_tick()

--- a/src/kage/web.py
+++ b/src/kage/web.py
@@ -1791,6 +1791,265 @@ class ToggleTaskRequest(BaseModel):
     file: str | None = None
 
 
+QUESTS_HTML = """<!DOCTYPE html>
+<html lang=\"ja\">
+<head>
+<meta charset=\"UTF-8\" />
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />
+<title>kage Quests</title>
+<style>
+:root{
+  --bg:#0d1117; --panel:#161b22; --panel2:#0f141b; --line:#30363d;
+  --ink:#c9d1d9; --dim:#8b949e; --faint:#484f58;
+  --accent:#58a6ff; --accent2:#5ad1a5; --warn:#d29922; --bad:#f85149;
+  --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  --sans:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);-webkit-font-smoothing:antialiased}
+.bar{padding:14px 20px;border-bottom:1px solid var(--line);display:flex;gap:14px;align-items:center;background:#010409;position:sticky;top:0;z-index:5}
+.bar h1{font-size:16px;margin:0;letter-spacing:-.01em}
+.bar .link{color:var(--accent);text-decoration:none;font-size:13px;margin-left:auto}
+.btn{background:var(--accent);color:#fff;border:none;border-radius:6px;padding:8px 14px;font-weight:600;cursor:pointer;font-size:13px}
+.btn.ghost{background:transparent;border:1px solid var(--line);color:var(--dim)}
+.wrap{max-width:1200px;margin:0 auto;padding:20px}
+.section{margin-bottom:18px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px}
+.section h2{margin:0 0 12px;font-size:15px;color:var(--accent2);letter-spacing:-.01em}
+.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:14px}
+.qcard{background:var(--panel2);border:1px solid var(--line);border-radius:8px;padding:14px;cursor:pointer;transition:border-color .15s}
+.qcard:hover{border-color:var(--accent)}
+.qcard .name{font-weight:600;font-size:14px}
+.qcard .id{font-family:var(--mono);font-size:11px;color:var(--faint)}
+.qcard .dir{color:var(--dim);font-size:12px;margin-top:6px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.stat{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px;font-size:11px;color:var(--dim)}
+.badge{font-family:var(--mono);font-size:10px;padding:3px 7px;border-radius:5px;border:1px solid var(--line)}
+.badge.active{color:var(--accent2);border-color:#1d4a39;background:rgba(90,209,165,.06)}
+.badge.done{color:var(--faint)}
+.badge.terminated,.badge.aborted{color:var(--bad);border-color:#4e1f1f;background:rgba(248,81,73,.06)}
+.badge.stopped{color:var(--warn);border-color:#553a17}
+.badge.proposed{color:#d2a8ff;border-color:#3a2a6e;background:rgba(210,168,255,.06)}
+.badge.pending{color:var(--dim)}
+.badge.growing{color:var(--accent2);border-color:#1d4a39}
+.badge.explored{color:var(--accent2);border-color:#1d4a39}
+.badge.running{color:var(--warn);border-color:#553a17}
+.bar.local{color:var(--accent2)}
+table{border-collapse:collapse;width:100%;font-size:12px}
+th,td{padding:7px 8px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+th{color:var(--dim);font-family:var(--mono);font-size:11px;font-weight:500;letter-spacing:.04em}
+svg.graph{width:100%;height:520px;background:#010409;border:1px solid var(--line);border-radius:8px;display:block}
+.legend{display:flex;flex-wrap:wrap;gap:14px;color:var(--dim);font-size:11px;margin-top:8px}
+.legend i{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:6px;vertical-align:middle}
+.empty{color:var(--faint);font-size:13px;padding:20px;text-align:center}
+.node-tooltip{font-size:11px}
+</style>
+</head>
+<body>
+<div class=\"bar\">
+  <h1>kage Quests</h1>
+  <span class=\"badge local\">event-driven · team mind-map</span>
+  <button class=\"btn ghost\" onclick=\"refresh()\">Refresh</button>
+  <a class=\"link\" href=\"/\">← Dashboard</a>
+</div>
+<div class=\"wrap\">
+  <div class=\"section\">
+    <h2>Quests</h2>
+    <div id=\"quest-list\" class=\"cards\"><div class=\"empty\">Loading…</div></div>
+  </div>
+  <div id=\"detail\" style=\"display:none\">
+    <div class=\"section\">
+      <h2 id=\"d-title\">…</h2>
+      <div id=\"d-meta\" class=\"stat\"></div>
+      <div id=\"d-graph\"></div>
+      <div class=\"legend\">
+        <span><i style=\"background:#d2a8ff\"></i>proposed (提案)</span>
+        <span><i style=\"background:#8b949e\"></i>pending</span>
+        <span><i style=\"background:#d29922\"></i>running</span>
+        <span><i style=\"background:#5ad1a5\"></i>explored/growing</span>
+        <span><i style=\"background:#f85149\"></i>aborted</span>
+        <span>&nbsp;\">spawned/promoted/grew_to/aborted_to\" edges</span>
+      </div>
+    </div>
+    <div class=\"section\">
+      <h2>Nodes</h2>
+      <div id=\"d-nodes\"></div>
+    </div>
+    <div class=\"section\">
+      <h2>Edges</h2>
+      <div id=\"d-edges\"></div>
+    </div>
+  </div>
+</div>
+<script>
+const STATUS = {
+  proposed:{label:'提案',cls:'proposed',fill:'#d2a8ff'},
+  pending:{label:'保留',cls:'pending',fill:'#8b949e'},
+  running:{label:'実行中',cls:'running',fill:'#d29922'},
+  explored:{label:'探索済',cls:'explored',fill:'#5ad1a5'},
+  growing:{label:'成長',cls:'growing',fill:'#5ad1a5'},
+  aborted:{label:'撤退',cls:'aborted',fill:'#f85149'},
+};
+const REL_COLOR = {
+  spawned:'#3a4858', promoted:'#5ad1a5', grew_to:'#7ee787',
+  aborted_to:'#f85149', proposed_from:'#d2a8ff',
+};
+let current = null;
+
+function escapeHtml(t){return t==null?'':String(t).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));}
+
+async function refresh(){
+  const list = document.getElementById('quest-list');
+  try {
+    const res = await fetch('/api/quests');
+    const quests = await res.json();
+    if (!quests.length){ list.innerHTML = '<div class=\"empty\">No quests · <code>kage quest new …</code></div>'; return; }
+    list.innerHTML = quests.map(q=>{
+      const st = q.status;
+      const progress = q.runs ? `runs ${q.runs}/${q.max_agent_runs||'∞'}` : '';
+      return `<div class=\"qcard\" onclick=\"selectQuest('${q.id}')\">
+        <div class=\"name\">${escapeHtml(q.name)}</div>
+        <div class=\"id\">${q.id} · mode=${q.mode||'team'} ${q.provider?('· '+escapeHtml(q.provider)):''}</div>
+        <div class=\"dir\">${escapeHtml(q.direction)}</div>
+        <div class=\"stat\">
+          <span class=\"badge ${st}\">${st}</span>
+          ${progress?`<span>${progress}</span>`:''}
+          <span>nodes: ${q.node_total||0}</span>
+        </div>
+      </div>`;
+    }).join('');
+  } catch(e){ list.innerHTML = '<div class=\"empty\">Failed to load. kage ui running?</div>'; }
+}
+
+async function selectQuest(id){
+  current = id;
+  const res = await fetch(`/api/quests/${id}`);
+  const q = await res.json();
+  document.getElementById('detail').style.display = 'block';
+  document.getElementById('d-title').textContent = `${q.name} · ${q.status}`;
+  const meta = document.getElementById('d-meta');
+  meta.innerHTML = `<span class=\"badge ${q.status}\">${q.status}</span>
+    <span>方向: ${escapeHtml(q.direction)}</span>
+    <span>runs ${q.agent_runs}/${q.max_agent_runs}</span>
+    <span>mode: ${q.mode||'team'}</span>
+    ${q.provider?`<span>provider: ${escapeHtml(q.provider)}</span>`:''}
+    <span>roles: ${(q.roles||[]).map(r=>escapeHtml(r)).join(', ')}</span>`;
+  renderGraph(q);
+  renderNodes(q);
+  renderEdges(q);
+}
+
+function renderGraph(q){
+  const nodes = q.nodes||[];
+  const edges = q.edges||[];
+  const W=1180,H=520,padX=40,padY=40;
+  const tiers = {};
+  const byId = {};
+  nodes.forEach(n=>{ byId[n.id]=n; });
+  function tierOf(n){
+    if (n.parent_id && byId[n.parent_id]) return tierOf(byId[n.parent_id])+1;
+    return 0;
+  }
+  nodes.forEach(n=>{ const t=tierOf(n); (tiers[t]=tiers[t]||[]).push(n); });
+  const maxTier = Math.max(0,...Object.keys(tiers).map(Number));
+  const positions = {};
+  Object.entries(tiers).forEach(([t,ns])=>{
+    const x = (W-padX*2)/(Math.max(1,ns.length))*0 + padX;
+    ns.forEach((n,i)=>{ positions[n.id] = { x: padX + (i+0.5)*(W-padX*2)/ns.length, y: padY + Number(t)*(H-padY*2)/Math.max(1,maxTier) }; });
+  });
+  const svg = [`<svg class=\"graph\" viewBox=\"0 0 ${W} ${H}\" xmlns=\"http://www.w3.org/2000/svg\">`,
+    `<defs><marker id=\"arrow\" markerWidth=\"10\" markerHeight=\"10\" refX=\"8\" refY=\"3\" orient=\"auto\"><path d=\"M0,0 L6,3 L0,6 Z\" fill=\"${'#3a4858'}\"/></marker></defs>`];
+  edges.forEach(e=>{
+    const a = positions[e.from_node], b = positions[e.to_node];
+    if (!a||!b) return;
+    const color = REL_COLOR[e.relation]||'#3a4858';
+    svg.push(`<line x1=\"${a.x}\" y1=\"${a.y}\" x2=\"${b.x}\" y2=\"${b.y}\" stroke=\"${color}\" stroke-width=\"1.5\" stroke-dasharray=\"${e.relation==='proposed_from'?'4 4':'none'}\" marker-end=\"url(#arrow)\"/>`);
+  });
+  nodes.forEach(n=>{
+    const p = positions[n.id]; if(!p) return;
+    const st = STATUS[n.status]||{fill:'#8b949e',label:n.status};
+    const isOwner = n.role==='owner';
+    svg.push(`<g transform=\"translate(${p.x},${p.y})\">`);
+    svg.push(`<circle r=\"14\" fill=\"${st.fill}\" fill-opacity=\"0.18\" stroke=\"${st.fill}\" stroke-width=\"${n.status==='proposed'?'1':'2'}\" stroke-dasharray=\"${n.status==='proposed'?'3 3':'none'}\"/>`);
+    if (isOwner){ svg.push(`<path d=\"M0,-20 -5,-14 0,-17 5,-14 Z\" fill=\"#5ad1a5\"/>`); }
+    svg.push(`<text text-anchor=\"middle\" y=\"32\" fill=\"${st.fill}\" font-size=\"10\" font-family=\"ui-monospace,monospace\">${n.role}:${n.status}</text>`);
+    svg.push(`<title>${escapeHtml(n.role+' / '+n.hypothesis)}</title>`);
+    svg.push(`</g>`);
+  });
+  svg.push('</svg>');
+  document.getElementById('d-graph').innerHTML = svg.join('');
+}
+
+function renderNodes(q){
+  const nodes = q.nodes||[];
+  if(!nodes.length){ document.getElementById('d-nodes').innerHTML='<div class=\"empty\">no nodes</div>'; return; }
+  const rows = nodes.map(n=>`<tr>
+    <td><code>${n.id}</code></td>
+    <td><span class=\"badge ${n.status}\">${n.status}</span></td>
+    <td>${n.role}</td>
+    <td>${n.parent_id?`<code>${n.parent_id}</code>`:'-'}</td>
+    <td>${n.proposed_by?escapeHtml(n.proposed_by):'-'}</td>
+    <td>${n.verdict||'-'}</td>
+    <td>${n.run_id||'-'}</td>
+    <td>${escapeHtml((n.evidence||'').slice(0,80))}</td>
+    <td>${escapeHtml((n.hypothesis||'').slice(0,120))}</td>
+  </tr>`).join('');
+  document.getElementById('d-nodes').innerHTML = `<table><thead><tr>
+    <th>id</th><th>status</th><th>role</th><th>parent</th><th>proposed_by</th><th>verdict</th><th>run_id</th><th>evidence</th><th>hypothesis</th>
+  </tr></thead><tbody>${rows}</tbody></table>`;
+}
+function renderEdges(q){
+  const edges = q.edges||[];
+  if(!edges.length){ document.getElementById('d-edges').innerHTML='<div class=\"empty\">no edges</div>'; return; }
+  const rows = edges.map(e=>`<tr><td><code>${e.id}</code></td><td>${e.from_node||'-'}</td><td>${e.to_node||'-'}</td><td>${e.relation}</td><td>${e.created_at||''}</td></tr>`).join('');
+  document.getElementById('d-edges').innerHTML = `<table><thead><tr><th>id</th><th>from</th><th>to</th><th>relation</th><th>created_at</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+refresh();
+setInterval(()=>{ refresh(); if(current) selectQuest(current); }, 5000);
+</script>
+</body>
+</html>"""
+
+
+def _quest_to_public_dict(q) -> dict:
+    from .quest import list_nodes, list_edges, node_counts
+
+    nodes = list_nodes(q.id)
+    edges = list_edges(q.id)
+    counts = node_counts(q.id)
+    payload = q.to_dict()
+    payload["node_total"] = counts.get("total", 0)
+    payload["node_counts"] = counts
+    payload["runs"] = counts.get("total", 0)
+    payload["nodes"] = [n.to_dict() for n in nodes]
+    payload["edges"] = [e.__dict__ for e in edges]
+    return payload
+
+
+@app.get("/api/quests")
+def api_quests_list(status: str | None = None, project: str | None = None):
+    from .quest import list_quests, node_counts
+
+    quests = list_quests(status_filter=status, project_filter=project)
+    out = []
+    for q in quests:
+        counts = node_counts(q.id)
+        d = q.to_dict()
+        d["node_total"] = counts.get("total", 0)
+        d["node_counts"] = counts
+        d["runs"] = counts.get("total", 0)
+        out.append(d)
+    return out
+
+
+@app.get("/api/quests/{quest_id}")
+def api_quest_detail(quest_id: str):
+    from .quest import get_quest
+
+    q = get_quest(quest_id)
+    if not q:
+        return JSONResponse(status_code=404, content={"error": "Quest not found."})
+    return _quest_to_public_dict(q)
+
+
 @app.get("/", response_class=HTMLResponse)
 @app.get("/runs", response_class=HTMLResponse)
 @app.get("/logs", response_class=HTMLResponse)
@@ -1798,6 +2057,11 @@ class ToggleTaskRequest(BaseModel):
 @app.get("/chat", response_class=HTMLResponse)
 def root():
     return INDEX_HTML
+
+
+@app.get("/quests", response_class=HTMLResponse)
+def quests_page():
+    return QUESTS_HTML
 
 
 @app.get("/api/runs")

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -1,0 +1,257 @@
+from pathlib import Path
+
+from kage import quest
+from kage.quest import QuestMode
+
+
+def _setup_tmp_db(mocker, tmp_path):
+    db_path = tmp_path / "kage.db"
+    mocker.patch("kage.db.KAGE_DB_PATH", db_path)
+    mocker.patch("kage.quest.KAGE_DB_PATH", db_path)
+
+
+def test_create_quest_and_structure(mocker, tmp_path: Path):
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "ocr-machine",
+        "find the best free OCR model for Japanese invoices",
+        max_agent_runs=3,
+        mode=QuestMode.SOLO,
+    )
+
+    assert q.status == quest.QUEST_STATUS_ACTIVE
+    assert q.agent_runs == 0
+    nodes = quest.list_nodes(q.id)
+    assert len(nodes) == 1
+    assert nodes[0].role == quest.ROLE_SCOUT
+    assert nodes[0].status == quest.NODE_STATUS_PENDING
+
+    quests = quest.list_quests()
+    assert len(quests) == 1
+    assert quests[0].id == q.id
+
+
+def test_tick_dispatches_scout_and_spawns_poc(mocker, tmp_path: Path):
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "explore",
+        "explore faster builds",
+        max_agent_runs=5,
+        mode=QuestMode.SOLO,
+    )
+
+    fake_run = mocker.Mock()
+    fake_run.id = "run-1"
+    fake_run.stdout = (
+        "scout done\n```json\n"
+        '{"verdict": "promising", "evidence": "two leads found", '
+        '"new_directions": ["try mold", "try sccache"]}\n'
+        "```"
+    )
+    mocker.patch(
+        "kage.executor.execute_task", return_value=mocker.Mock(value="started")
+    )
+    mocker.patch(
+        "kage.runs.list_runs",
+        return_value=[fake_run],
+    )
+
+    summaries = quest.tick()
+    assert summaries and summaries[0]["action"] == "dispatched"
+
+    nodes = quest.list_nodes(q.id)
+    assert len(nodes) == 3  # scout + 2 spawned poc
+    scout = [n for n in nodes if n.role == quest.ROLE_SCOUT][0]
+    assert scout.status == quest.NODE_STATUS_GROWING
+    assert scout.verdict == "promising"
+    pocs = [n for n in nodes if n.role == quest.ROLE_POC]
+    assert {n.hypothesis for n in pocs} == {"try mold", "try sccache"}
+    edges = quest.list_edges(q.id)
+    assert all(e.relation == "grew_to" for e in edges)
+    fresh = quest.get_quest(q.id)
+    assert fresh.agent_runs == 1
+
+
+def test_tick_terminates_on_budget(mocker, tmp_path: Path):
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "capped",
+        "x",
+        max_agent_runs=0,
+        mode=QuestMode.SOLO,
+    )
+    summaries = quest.tick()
+    assert summaries[0]["action"] == "terminated"
+    assert quest.get_quest(q.id).status == quest.QUEST_STATUS_TERMINATED
+
+
+def test_tick_dead_poc_spawns_strategist_then_done(mocker, tmp_path: Path):
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "dead end",
+        "y",
+        max_agent_runs=10,
+        mode=QuestMode.SOLO,
+    )
+
+    # First tick: scout dead -> spawn strategist node
+    run1 = mocker.Mock()
+    run1.id = "r1"
+    run1.stdout = (
+        "```json\n"
+        '{"verdict": "dead", "evidence": "nothing here", "new_directions": []}\n'
+        "```"
+    )
+    mocker.patch(
+        "kage.executor.execute_task", return_value=mocker.Mock(value="started")
+    )
+    mocker.patch("kage.runs.list_runs", return_value=[run1])
+    quest.tick()
+
+    nodes = quest.list_nodes(q.id)
+    assert any(n.role == quest.ROLE_STRATEGIST for n in nodes)
+
+    # Second tick: strategist dead -> quest done
+    run2 = mocker.Mock()
+    run2.id = "r2"
+    run2.stdout = (
+        "```json\n"
+        '{"verdict": "dead", "evidence": "exhausted", "new_directions": []}\n'
+        "```"
+    )
+    mocker.patch("kage.runs.list_runs", return_value=[run2])
+    quest.tick()
+
+    assert quest.get_quest(q.id).status == quest.QUEST_STATUS_DONE
+
+
+def test_parse_verdict_handles_missing_block():
+    assert quest._parse_verdict("no json here") is None
+    payload = quest._parse_verdict(
+        'blah\n```json\n{"verdict": "promising", "new_directions": []}\n```\n'
+    )
+    assert payload == {"verdict": "promising", "new_directions": []}
+
+
+def test_team_mode_defers_until_evidence(mocker, tmp_path: Path):
+    """In team mode the owner should not run when evidence is empty."""
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "team quest",
+        "find a faster bundler",
+        max_agent_runs=20,
+        mode=QuestMode.TEAM,
+    )
+    nodes = quest.list_nodes(q.id)
+    assert len(nodes) == 1
+    assert nodes[0].role == quest.ROLE_OWNER
+    assert nodes[0].status == quest.NODE_STATUS_PENDING
+
+    # No completed/pending evidence yet — _should_dispatch_owner returns
+    # True in the empty case (pending_n <= 1) so the owner can kick off.
+    assert quest._should_dispatch_owner(quest._connect(), q.id) is True
+
+
+def test_team_mode_scout_emits_proposed_not_pending(mocker, tmp_path: Path):
+    """Scout's grown children must land as 'proposed', not 'pending'."""
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "team quest",
+        "find a faster bundler",
+        max_agent_runs=20,
+        mode=QuestMode.TEAM,
+    )
+    # First tick dispatches the owner; owner emits actions: spawn scout.
+    owner_run = mocker.Mock()
+    owner_run.id = "r-owner"
+    owner_run.stdout = (
+        "```json\n"
+        '{"evidence": "kick off", "actions": ['
+        '{"type": "spawn", "role": "scout", "direction": "measure ts vs esbuild"}'
+        "]}\n"
+        "```"
+    )
+    mocker.patch(
+        "kage.executor.execute_task", return_value=mocker.Mock(value="started")
+    )
+    mocker.patch("kage.runs.list_runs", return_value=[owner_run])
+    quest.tick()
+
+    scout = [n for n in quest.list_nodes(q.id) if n.role == quest.ROLE_SCOUT]
+    assert len(scout) == 1
+    assert scout[0].status == quest.NODE_STATUS_PROPOSED
+    assert scout[0].proposed_by == quest.ROLE_OWNER
+
+
+def test_team_mode_promote_via_owner_action(mocker, tmp_path: Path):
+    """Owner's promote action flips a proposed node to pending."""
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "team quest",
+        "x",
+        max_agent_runs=20,
+        mode=QuestMode.TEAM,
+    )
+    owner_run = mocker.Mock()
+    owner_run.id = "r1"
+    scout_hyp = "try vite"
+    owner_run.stdout = (
+        "```json\n"
+        '{"evidence": "init", "actions": ['
+        f'{{"type": "spawn", "role": "scout", "direction": "{scout_hyp}"}}'
+        "]}\n"
+        "```"
+    )
+    mocker.patch(
+        "kage.executor.execute_task", return_value=mocker.Mock(value="started")
+    )
+    mocker.patch("kage.runs.list_runs", return_value=[owner_run])
+    quest.tick()
+
+    scout = [n for n in quest.list_nodes(q.id) if n.role == quest.ROLE_SCOUT][0]
+    assert scout.status == quest.NODE_STATUS_PROPOSED
+
+    # Second tick: owner promotes the scout.
+    promote_run = mocker.Mock()
+    promote_run.id = "r2"
+    promote_run.stdout = (
+        "```json\n"
+        f'{{"evidence": "ok", "actions": [{{"type": "promote", "node_id": "{scout.id}"}}]}}\n'
+        "```"
+    )
+    mocker.patch("kage.runs.list_runs", return_value=[promote_run])
+    quest.tick()
+
+    scout = quest.get_node(scout.id)
+    assert scout.status == quest.NODE_STATUS_PENDING
+
+
+def test_team_mode_finish_ends_quest(mocker, tmp_path: Path):
+    """Owner's finish flag closes the quest."""
+    _setup_tmp_db(mocker, tmp_path)
+    q = quest.create_quest(
+        str(tmp_path),
+        "team quest",
+        "x",
+        max_agent_runs=20,
+        mode=QuestMode.TEAM,
+    )
+    finish_run = mocker.Mock()
+    finish_run.id = "r-fin"
+    finish_run.stdout = (
+        '```json\n{"evidence": "done here", "finish": true, "actions": []}\n```'
+    )
+    mocker.patch(
+        "kage.executor.execute_task", return_value=mocker.Mock(value="started")
+    )
+    mocker.patch("kage.runs.list_runs", return_value=[finish_run])
+    quest.tick()
+
+    assert quest.get_quest(q.id).status == quest.QUEST_STATUS_DONE

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -46,6 +46,7 @@ def test_scheduler_skips_current_and_invalid_suspensions(mocker, tmp_path: Path)
     )
     execute_task = mocker.patch("kage.scheduler.execute_task")
     mocker.patch("kage.connectors.runner.run_connectors")
+    mocker.patch("kage.quest.tick")
 
     run_all_scheduled_tasks()
 
@@ -88,6 +89,7 @@ def test_scheduler_uses_project_timezone_for_date_only_suspension(
     )
     execute_task = mocker.patch("kage.scheduler.execute_task")
     mocker.patch("kage.connectors.runner.run_connectors")
+    mocker.patch("kage.quest.tick")
 
     run_all_scheduled_tasks()
 

--- a/uv.lock
+++ b/uv.lock
@@ -111,7 +111,7 @@ wheels = [
 
 [[package]]
 name = "kage-ai"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Add the **quest lifecycle**: an event-driven, team-based alternative to the cron task lifecycle. Each quest dispatches role agents (scout → poc → strategist) as a mind-map graph, advancing exactly one node per cron tick and bounded by a \`--max-agent-runs\` runaway budget. Quest runs flow through the normal executor so they appear in \`kage runs\` / \`kage logs\` alongside scheduled tasks.

This PR is split out from the agent PR (#32) so the agent-isolation work stays focused. Base is \`feat/agent-memory-isolation\` — quest tables and commands layer naturally on top of \`executions.agent_name\`.

### Backend (src/kage/quest.py)
- Quest / QuestNode / QuestEdge models and helpers.
- \`create_quest\` / \`list_quests\` / \`get_quest\` / \`set_quest_status\`.
- \`list_nodes\` / \`list_edges\` / \`abort_node\`.
- \`tick()\` advances active quests one pending node per call: spawns successors (scout → poc → strategist), finalizes the quest once all branches are done, and emits ordinary executions for each dispatched node.

### DB (src/kage/db.py)
- \`_ensure_quest_tables\`: idempotent CREATE TABLE for \`quests\`, \`quest_nodes\`, \`quest_edges\` (+ ALTER ADD COLUMN for legacy v1/v2 schema rows).

### CLI (src/kage/main.py)
- \`kage quest new <name> --direction '...' [--max-agent-runs N] [--solo]\`
- \`kage quest list\` / \`show <id>\` / \`stop <id>\` / \`resume <id>\` / \`abort-node <node_id>\`
- Quest status appears in \`kage runs list\` and \`kage doctor\`.

### Scheduler
- \`run_all_scheduled_tasks()\` now calls \`quest_tick()\` at the end of every tick so active quests advance automatically under \`kage cron run\`.

### Web / TUI
- \`/api/quests\` endpoints + connector artifact hooks surface quest state.

### Tests
- \`tests/test_quest.py\` (9 cases): tick transitions and team-mode evidence gating / promotion.
- \`tests/test_scheduler.py\`: scheduler integration.

### Docs
- README / README_JA / SKILL.md: quest command rows restored.
- \`docs/quest/2026-06-24-quest-lifecycle/\`: design intent + report.

## Tests
\`uv run pytest -q\` → 196 passed (including the 187 agent-PR tests + 9 quest tests).

## Release label
Release label は不要です — 機能自体はユーザー向け新機能ですが、ベースが未マージの agent PR なので stck します。agent PR のマージ後に rebase してから \`release:minor\` を付与します（現 PR では \"意図的に label なし\" と明記しました）。