### PR TITLE
feat(connectors): add default system prompts for formatting rules

### DIFF
--- a/src/kage/connectors/discord.py
+++ b/src/kage/connectors/discord.py
@@ -18,6 +18,12 @@ from ..connector_payload import (
 from ..runs import write_run_metadata
 from .base import BaseConnector
 
+DEFAULT_DISCORD_SYSTEM_PROMPT = """You are communicating with the user via Discord.
+Please adhere to the following formatting rules:
+- Discord does NOT support Markdown tables natively. If you need to present tabular data, you MUST use an ASCII table inside a code block (```).
+- Use standard Markdown for bold (**text**), italics (*text*), and code blocks (```).
+- Do not use HTML tags."""
+
 
 class DiscordConnector(BaseConnector):
     GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
@@ -189,10 +195,15 @@ class DiscordConnector(BaseConnector):
 
         agent = get_agent_for_connector(config, self.name, self._config_dict())
         composed_system = build_full_system_prompt(config, agent)
-        if self.config.system_prompt:
+
+        system_prompt = self.config.system_prompt
+        if not system_prompt:
+            system_prompt = DEFAULT_DISCORD_SYSTEM_PROMPT
+
+        if system_prompt:
             composed_system = (
                 f"{composed_system}\n\n[Connector Instructions]\n"
-                f"{self.config.system_prompt.strip()}"
+                f"{system_prompt.strip()}"
             )
         connector_meta = {
             "connector": {

--- a/src/kage/connectors/slack.py
+++ b/src/kage/connectors/slack.py
@@ -16,6 +16,12 @@ from ..connector_payload import (
 from ..runs import write_run_metadata
 from .base import BaseConnector
 
+DEFAULT_SLACK_SYSTEM_PROMPT = """You are communicating with the user via Slack.
+Please adhere to the following formatting rules:
+- Slack does NOT support Markdown tables natively. If you need to present tabular data, you MUST use an ASCII table inside a code block (```).
+- Slack does NOT support standard Markdown headers (like # Header). Use bold text (*text*) for emphasis instead.
+- Do not use HTML tags."""
+
 
 class SlackConnector(BaseConnector):
     def __init__(self, name: str, config):
@@ -214,10 +220,15 @@ class SlackConnector(BaseConnector):
             config = get_global_config()
             agent = get_agent_for_connector(config, self.name, self._config_dict())
             composed_system = build_full_system_prompt(config, agent)
-            if self.config.system_prompt:
+
+            system_prompt = self.config.system_prompt
+            if not system_prompt:
+                system_prompt = DEFAULT_SLACK_SYSTEM_PROMPT
+
+            if system_prompt:
                 composed_system = (
                     f"{composed_system}\n\n[Connector Instructions]\n"
-                    f"{self.config.system_prompt.strip()}"
+                    f"{system_prompt.strip()}"
                 )
             working_dir = self.config.working_dir or agent.default_working_dir
             connector_meta = {

--- a/src/kage/connectors/telegram.py
+++ b/src/kage/connectors/telegram.py
@@ -16,6 +16,12 @@ from ..connector_payload import (
 from ..runs import write_run_metadata
 from .base import BaseConnector
 
+DEFAULT_TELEGRAM_SYSTEM_PROMPT = """You are communicating with the user via Telegram.
+Please adhere to the following formatting rules:
+- Telegram does NOT support standard Markdown tables. If you need to present tabular data, you MUST use an ASCII table inside a code block (```).
+- Telegram's Markdown parsing is strict. Stick to basic formatting like bold (**text**), italics (*text*), and code blocks (```).
+- Do not use HTML tags."""
+
 
 class TelegramConnector(BaseConnector):
     def __init__(self, name: str, config):
@@ -291,10 +297,15 @@ class TelegramConnector(BaseConnector):
             config = get_global_config()
             agent = get_agent_for_connector(config, self.name, self._config_dict())
             composed_system = build_full_system_prompt(config, agent)
-            if self.config.system_prompt:
+
+            system_prompt = self.config.system_prompt
+            if not system_prompt:
+                system_prompt = DEFAULT_TELEGRAM_SYSTEM_PROMPT
+
+            if system_prompt:
                 composed_system = (
                     f"{composed_system}\n\n[Connector Instructions]\n"
-                    f"{self.config.system_prompt.strip()}"
+                    f"{system_prompt.strip()}"
                 )
             working_dir = self.config.working_dir or agent.default_working_dir
             from_user = target_msg.get("from", {})


### PR DESCRIPTION
Adds fallback default system prompts to Discord, Slack, and Telegram connectors to guide the AI regarding each platform's formatting limitations (like Markdown tables not being supported, preferring ascii tables).