### PR TITLE
fix(rate_limit): detect 'Individual quota reached' and compact duration units

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kage-ai"
-version = "0.15.2"
+version = "0.15.3"
 description = "AI-native cron task runner for per-project scheduled prompts and commands."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/kage/rate_limit.py
+++ b/src/kage/rate_limit.py
@@ -17,14 +17,17 @@ _LIMIT_KEYWORDS = [
     "rate limit",
     "usage limit",
     "usage limit reached",
+    "quota exceeded",
+    "quota reached",
+    "individual quota",
     "too many requests",
     "resource exhausted",
-    "quota exceeded",
     "you've hit your limit",
     "you have hit your limit",
     "you've hit your usage limit",
     "you have hit your usage limit",
     "refreshes in",
+    "resets in",
 ]
 
 _MONTHS = {
@@ -42,9 +45,10 @@ _MONTHS = {
     "dec": 12,
 }
 
-# e.g. "2 days", "17 hours", "14 minutes", "30 seconds", "1 week"
+# e.g. "2 days", "17 hours", "14 minutes", "30 seconds", "1 week",
+# "122h48m19s"
 _DURATION_TOKEN_RE = re.compile(
-    r"(~?\d+)\s*(weeks?|w|days?|hours?|hrs?|hr|minutes?|mins?|min|seconds?|secs?|sec)",
+    r"(~?\d+)\s*(weeks?|w|days?|d|hours?|hrs?|hr|h|minutes?|mins?|min|m|seconds?|secs?|sec|s)",
     re.IGNORECASE,
 )
 
@@ -111,13 +115,13 @@ def _parse_duration_tokens(segment: str) -> Optional[timedelta]:
         unit = match.group(2).lower()
         if unit.startswith("week") or unit == "w":
             total += timedelta(weeks=value)
-        elif unit.startswith("day"):
+        elif unit.startswith("day") or unit == "d":
             total += timedelta(days=value)
-        elif unit.startswith("hour") or unit.startswith("hr"):
+        elif unit.startswith("hour") or unit.startswith("hr") or unit == "h":
             total += timedelta(hours=value)
-        elif unit.startswith("minute") or unit.startswith("min"):
+        elif unit.startswith("minute") or unit.startswith("min") or unit == "m":
             total += timedelta(minutes=value)
-        elif unit.startswith("second") or unit.startswith("sec"):
+        elif unit.startswith("second") or unit.startswith("sec") or unit == "s":
             total += timedelta(seconds=value)
     return total if found else None
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -106,6 +106,27 @@ def test_rate_limit_state_skip_and_clear(tmp_path, monkeypatch):
     assert is_model_rate_limited("codex", "gpt-5", now=now) is False
 
 
+def test_detects_individual_quota_reached_with_compact_duration():
+    now = _make_now()
+    stderr = (
+        "Error generating reply: Error: Individual quota reached. "
+        "Please upgrade your subscription to increase your limits. "
+        "Resets in 122h48m19s."
+    )
+    info = parse_rate_limit_info("", stderr, now=now)
+    assert info.is_limited is True
+    expected = now + timedelta(hours=122, minutes=48, seconds=19)
+    assert abs(info.reset_at - expected) < timedelta(seconds=1)
+
+
+def test_detects_single_letter_duration_units():
+    now = _make_now()
+    info = parse_rate_limit_info("", "Quota reached. Resets in 1w2d3h4m5s.", now=now)
+    assert info.is_limited is True
+    expected = now + timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5)
+    assert abs(info.reset_at - expected) < timedelta(seconds=1)
+
+
 def test_rate_limit_info_defaults():
     info = RateLimitInfo()
     assert info.is_limited is False

--- a/uv.lock
+++ b/uv.lock
@@ -111,7 +111,7 @@ wheels = [
 
 [[package]]
 name = "kage-ai"
-version = "0.15.1"
+version = "0.15.3"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Fixes model fallback not triggering for the error:

> Error generating reply: Error: Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 122h48m19s.

## Changes

- Added rate-limit detection keywords: `quota reached`, `individual quota`, `resets in`.
- Added parsing for compact duration units (`d`, `h`, `m`, `s`) so resets like `122h48m19s` are handled.
- Bumped version to 0.15.3.

## Verification

- `uvx ruff format . && uvx ruff check . --fix` passed.
- `uv run pytest`: 212 tests passed.

release:patch